### PR TITLE
feat: Set 'allowEmptyScopes' based on commitlint config

### DIFF
--- a/docs/guide/option-engineer.md
+++ b/docs/guide/option-engineer.md
@@ -45,6 +45,10 @@ It will automatically detect whether the definition of the [commitlint](https://
 - **type** : `boolean`
 - **default** : `true`
 
+:::tip
+It will automatically detect whether the definition of the [commitlint](https://github.com/conventional-changelog/commitlint) rule `scope-empty` is strict, and it will not be displayed automatically.
+:::
+
 ## allowBreakingChanges
 
 - **description** : a specific **type** that allows BREAKING CHANGES

--- a/docs/zh/guide/option-engineer.md
+++ b/docs/zh/guide/option-engineer.md
@@ -46,6 +46,9 @@ lastUpdated: true
 - **类型** : `boolean`
 - **默认** : `true`
 
+:::tip
+会自动检测 [commitlint](https://github.com/conventional-changelog/commitlint) 规则 `scope-empty`的定义是否严格，自动不显示。
+:::
 
 ## allowBreakingChanges
 

--- a/packages/cz-git/src/loader.ts
+++ b/packages/cz-git/src/loader.ts
@@ -17,6 +17,7 @@ import {
   buildCommit,
   log,
   enumRuleIsActive,
+  ruleIsActive,
   getEnumList,
   getValueByCallBack
 } from "./until";
@@ -54,7 +55,7 @@ export const generateOptions = (clConfig: UserConfig): CommitizenGitOptions => {
     scopes: pkgConfig.scopes ?? clPromptConfig.scopes ?? getEnumList(clConfig?.rules?.["scope-enum"] as any),
     scopeOverrides: pkgConfig.scopeOverrides ?? clPromptConfig.scopeOverrides ?? defaultConfig.scopeOverrides,
     allowCustomScopes: pkgConfig.allowCustomScopes ?? clPromptConfig.allowCustomScopes ?? !enumRuleIsActive(clConfig?.rules?.["scope-enum"] as any),
-    allowEmptyScopes: pkgConfig.allowEmptyScopes ?? clPromptConfig.allowEmptyScopes ?? defaultConfig.allowEmptyScopes,
+    allowEmptyScopes: pkgConfig.allowEmptyScopes ?? clPromptConfig.allowEmptyScopes ?? !ruleIsActive(clConfig?.rules?.["scope-empty"] as any),
     customScopesAlign: pkgConfig.customScopesAlign ?? clPromptConfig.customScopesAlign ?? defaultConfig.customScopesAlign,
     customScopesAlias: pkgConfig.customScopesAlias ?? clPromptConfig.customScopesAlias ?? defaultConfig.customScopesAlias,
     emptyScopesAlias: pkgConfig.emptyScopesAlias ?? clPromptConfig.emptyScopesAlias ?? defaultConfig.emptyScopesAlias,


### PR DESCRIPTION
## Related ISSUE

#15 

## Type Of Change

- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 📝 Document (This change requires a documentation update)
- [ ] 🎨 Theme style (Theme style beautification)
- [ ] ⚠  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔨 Workflow (Workflow changes)

## Clear Describe

> A clear and concise description of what update for target.

- feat(cz-git): allowEmptyScopes can base on ["scope-empty"] rule
- docs(guide): add allowEmptyScopes base commitlint guide

## Description

> Respect commitlint option about empty scopes by default

Thx @jaklan feature suggestion

But A principle, if you set it to warning, then I will not hide custom, if you set it to error, strict, I will hide it. After all this is whether commitlint affects the commit. We are just an auxiliary generative role.

## Test Case

set commlint like:
```
rules: {
    "scope-empty": [2, "never"]
  }
```
