### PR TITLE
feat(cz-git): add `markBreakingChangeMode` options to add extra prompt mark `!`

### DIFF
--- a/docs-zh/.vitepress/configs/sidebar/zh.ts
+++ b/docs-zh/.vitepress/configs/sidebar/zh.ts
@@ -50,6 +50,10 @@ export const zh: DefaultTheme.Sidebar = {
           link: "/recipes/"
         },
         {
+          text: "markBreakingChange",
+          link: "/recipes/breakingchange"
+        },
+        {
           text: "issuePrefixs",
           link: "/recipes/issuePrefixs"
         },

--- a/docs-zh/config/engineer.md
+++ b/docs-zh/config/engineer.md
@@ -76,6 +76,17 @@ sitemap:
 会自动检测 [commitlint](https://github.com/conventional-changelog/commitlint) 规则 `scope-empty`的定义是否严格，自动不显示。
 :::
 
+## markBreakingChangeMode
+
+- **描述** : 添加额外的问题重大变更(BREAKING CHANGES)提问，询问是否需要添加 =="!"== 标识于头部
+- **使用** : 当你想添加 ! 标识于头部，表明该 commit 为重大变更时，请使用该选项
+- **类型** : `boolean`
+- **默认** : `false`
+
+:::tip
+更多用法与示例 [⇒ 查看小窍门](/recipes/breakingchange.html)
+:::
+
 ## allowBreakingChanges
 
 - **描述** : 允许出现 重大变更(BREAKING CHANGES)的特定 **type**

--- a/docs-zh/recipes/breakingchange.md
+++ b/docs-zh/recipes/breakingchange.md
@@ -1,0 +1,51 @@
+# markBreakingChangeMode
+
+> 添加 ! 标识，表明该 commit 消息属于重大变更
+
+See: 该规则来自 [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#examples)<br>
+E.g:
+```text
+# Commit message 带有 ! 提示重大变更
+feat!: send an email to the customer when a product is shipped
+
+# Commit message 与范围以及 ! 标识提示重大变更
+feat(api)!: send an email to the customer when a product is shipped
+
+# Commit message 带有 ! 提示重大变更以及底部说明
+chore!: drop support for Node 6
+
+BREAKING CHANGE: use JavaScript features not available in Node 6.
+```
+
+## 使用配置项: `markBreakingChangeMode`
+> 改变 "BREAKINGCHANGE"的提问方式，询问是否需要添加 =="!"== 标识
+
+```js{6}
+// .commitlintrc.js
+
+/** @type {import('cz-git').UserConfig} */
+module.exports = {
+  prompt: {
+    markBreakingChangeMode: true
+  }
+};
+```
+
+示例:
+![demo](https://user-images.githubusercontent.com/40693636/174950214-b294413c-b2b4-4e5b-9b8d-38deab9e8485.gif)
+
+## 使用 commitizen CLI + cz-git
+可以尝试运行命令自动添加标识:
+```bash
+break=1 cz
+```
+示例:
+![demo](https://user-images.githubusercontent.com/40693636/174949733-d5cd7f0d-ac81-40e8-8cb9-158737330d7a.gif)
+
+## 使用 cz-git CLI `czg`
+可以尝试运行命令自动添加标识:
+```bash
+czg break
+```
+示例:
+

--- a/docs/.vitepress/configs/sidebar/en.ts
+++ b/docs/.vitepress/configs/sidebar/en.ts
@@ -50,6 +50,10 @@ export const en: DefaultTheme.Sidebar = {
           link: "/recipes/"
         },
         {
+          text: "markBreakingChange",
+          link: "/recipes/breakingchange"
+        },
+        {
           text: "defaultScope",
           link: "/recipes/defaultScope"
         },

--- a/docs/.vitepress/configs/sidebar/zh.ts
+++ b/docs/.vitepress/configs/sidebar/zh.ts
@@ -50,6 +50,10 @@ export const zh: DefaultTheme.Sidebar = {
           link: "/zh/recipes/"
         },
         {
+          text: "markBreakingChange",
+          link: "/zh/recipes/breakingchange"
+        },
+        {
           text: "issuePrefixs",
           link: "/zh/recipes/issuePrefixs"
         },

--- a/docs/config/engineer.md
+++ b/docs/config/engineer.md
@@ -74,6 +74,17 @@ It will automatically detect whether the definition of the [commitlint](https://
 It will automatically detect whether the definition of the [commitlint](https://github.com/conventional-changelog/commitlint) rule `scope-empty` is strict, and it will not be displayed automatically.
 :::
 
+## markBreakingChangeMode
+
+- **description** : Add an extra BREAKINGCHANGE question asking if you need to add the =="!"== mark in the header
+- **use** : When you want to add the ! mark in the header, Highlight that the commit message belongs to BREAKINGCHANGE. you can use this option.
+- **type** : `boolean`
+- **default** : `false`
+
+:::tip
+more usage and demo [⇒ see the recipes](/recipes/breakingchange.html)
+:::
+
 ## allowBreakingChanges
 
 - **description** : a specific **type** that allows BREAKING CHANGES

--- a/docs/recipes/breakingchange.md
+++ b/docs/recipes/breakingchange.md
@@ -1,0 +1,51 @@
+# markBreakingChangeMode
+
+> Add the ! mark in the header, Highlight that the commit message belongs to BREAKINGCHANGE. 
+
+See: The rule by [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#examples)<br>
+E.g:
+```text
+# Commit message with ! to draw attention to breaking change
+feat!: send an email to the customer when a product is shipped
+
+# Commit message with scope and ! to draw attention to breaking change
+feat(api)!: send an email to the customer when a product is shipped
+
+# Commit message with both ! and BREAKING CHANGE footer
+chore!: drop support for Node 6
+
+BREAKING CHANGE: use JavaScript features not available in Node 6.
+```
+
+## Use Option: `markBreakingChangeMode`
+> Change "BREAKINGCHANGE" question that if you need to add the =="!"== mark in the header
+
+```js{6}
+// .commitlintrc.js
+
+/** @type {import('cz-git').UserConfig} */
+module.exports = {
+  prompt: {
+    markBreakingChangeMode: true
+  }
+};
+```
+
+Demo:
+![demo](https://user-images.githubusercontent.com/40693636/174950214-b294413c-b2b4-4e5b-9b8d-38deab9e8485.gif)
+
+## Use commitizen CLI + cz-git
+Try running command:
+```bash
+break=1 cz
+```
+Demo:
+![demo](https://user-images.githubusercontent.com/40693636/174949733-d5cd7f0d-ac81-40e8-8cb9-158737330d7a.gif)
+
+## Use cz-git CLI `czg`
+Try running command:
+```bash
+czg break
+```
+Demo:
+

--- a/docs/zh/config/engineer.md
+++ b/docs/zh/config/engineer.md
@@ -33,7 +33,6 @@ sitemap:
 
 ## scopeFilters
 
-- **描述** : Filter select of prompt to select module scopes by the scope.value
 - **描述** : 根据 scope.value 过滤模块范围中的选项
 - **类型** : string[]
 - **默认** : `[".DS_Store"]`
@@ -74,6 +73,17 @@ sitemap:
 
 :::tip
 会自动检测 [commitlint](https://github.com/conventional-changelog/commitlint) 规则 `scope-empty`的定义是否严格，自动不显示。
+:::
+
+## markBreakingChangeMode
+
+- **描述** : 添加额外的问题重大变更(BREAKING CHANGES)提问，询问是否需要添加 =="!"== 标识于头部
+- **使用** : 当你想添加 ! 标识于头部，表明该 commit 为重大变更时，请使用该选项
+- **类型** : `boolean`
+- **默认** : `false`
+
+:::tip
+更多用法与示例 [⇒ 查看小窍门](/zh/recipes/breakingchange.html)
 :::
 
 ## allowBreakingChanges

--- a/docs/zh/recipes/breakingchange.md
+++ b/docs/zh/recipes/breakingchange.md
@@ -1,0 +1,51 @@
+# markBreakingChangeMode
+
+> 添加 ! 标识，表明该 commit 消息属于重大变更
+
+See: 该规则来自 [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#examples)<br>
+E.g:
+```text
+# Commit message 带有 ! 提示重大变更
+feat!: send an email to the customer when a product is shipped
+
+# Commit message 与范围以及 ! 标识提示重大变更
+feat(api)!: send an email to the customer when a product is shipped
+
+# Commit message 带有 ! 提示重大变更以及底部说明
+chore!: drop support for Node 6
+
+BREAKING CHANGE: use JavaScript features not available in Node 6.
+```
+
+## 使用配置项: `markBreakingChangeMode`
+> 改变 "BREAKINGCHANGE"的提问方式，询问是否需要添加 =="!"== 标识
+
+```js{6}
+// .commitlintrc.js
+
+/** @type {import('cz-git').UserConfig} */
+module.exports = {
+  prompt: {
+    markBreakingChangeMode: true
+  }
+};
+```
+
+示例:
+![demo](https://user-images.githubusercontent.com/40693636/174950214-b294413c-b2b4-4e5b-9b8d-38deab9e8485.gif)
+
+## 使用 commitizen CLI + cz-git
+可以尝试运行命令自动添加标识:
+```bash
+break=1 cz
+```
+示例:
+![demo](https://user-images.githubusercontent.com/40693636/174949733-d5cd7f0d-ac81-40e8-8cb9-158737330d7a.gif)
+
+## 使用 cz-git CLI `czg`
+可以尝试运行命令自动添加标识:
+```bash
+czg break
+```
+示例:
+

--- a/packages/cz-git/__tests__/generateMessage.test.ts
+++ b/packages/cz-git/__tests__/generateMessage.test.ts
@@ -119,4 +119,30 @@ closed #12`
 closed #12`
     );
   });
+
+  test("turn on markBreaking shoule be output ! mark after type", () => {
+    const options = {
+      types: [{ value: "feat", name: "feat:     A new feature" }]
+    };
+    const answers = {
+      type: "feat",
+      subject: "add a new feature",
+      markBreaking: "true"
+    };
+    expect(generateMessage(answers, options)).toEqual(`feat!: add a new feature`);
+  });
+
+  test("turn on markBreaking shoule be output ! mark follow scope", () => {
+    const options = {
+      types: [{ value: "feat", name: "feat:     A new feature" }],
+      scopes: ["app"]
+    };
+    const answers = {
+      type: "feat",
+      scope: "app",
+      subject: "add a new feature",
+      markBreaking: "true"
+    };
+    expect(generateMessage(answers, options)).toEqual(`feat(app)!: add a new feature`);
+  });
 });

--- a/packages/cz-git/src/generator/message.ts
+++ b/packages/cz-git/src/generator/message.ts
@@ -35,10 +35,14 @@ const getSingleParams = (answers: Answers, options: CommitizenGitOptions) => {
 const addType = (type: string, colorize?: boolean) => (colorize ? style.green(type) : type);
 
 const addScope = (scope?: string, colorize?: boolean) => {
-  const separator = ":";
-  if (!scope) return separator;
+  if (!scope) return "";
   scope = colorize ? style.yellow(scope) : scope;
-  return `(${scope.trim()})${separator}`;
+  return `(${scope.trim()})`;
+};
+
+const addBreakchangeMark = (markBreaking?: string, colorize?: boolean) => {
+  const mark = colorize ? style.red("!") : "!";
+  return Boolean(markBreaking) || Boolean(process.env.break === "1") ? mark : "";
 };
 
 const addEmoji = (type: string, options: CommitizenGitOptions): string => {
@@ -85,6 +89,8 @@ export const generateMessage = (
   const head =
     addType(answers.type ?? "", colorize) +
     addScope(singleScope || scope, colorize) +
+    addBreakchangeMark(answers.markBreaking, colorize) +
+    ":" +
     addEmoji(answers.type ?? "", options) +
     addSubject(answers.subject, colorize);
   const body = wrap(answers.body ?? "", wrapOptions);

--- a/packages/cz-git/src/generator/message.ts
+++ b/packages/cz-git/src/generator/message.ts
@@ -37,10 +37,10 @@ const addType = (type: string, colorize?: boolean) => (colorize ? style.green(ty
 const addScope = (scope?: string, colorize?: boolean) => {
   if (!scope) return "";
   scope = colorize ? style.yellow(scope) : scope;
-  return `(${scope.trim()})`;
+  return `(${scope?.trim()})`;
 };
 
-const addBreakchangeMark = (markBreaking?: string, colorize?: boolean) => {
+const addBreakchangeMark = (markBreaking?: string | boolean, colorize?: boolean) => {
   const mark = colorize ? style.red("!") : "!";
   return Boolean(markBreaking) || Boolean(process.env.break === "1") ? mark : "";
 };

--- a/packages/cz-git/src/generator/option.ts
+++ b/packages/cz-git/src/generator/option.ts
@@ -25,11 +25,11 @@ export const generateOptions = (config: UserConfig): CommitizenGitOptions => {
     themeColorCode: ___X_CMD_THEME_COLOR_CODE || promptConfig.themeColorCode || defaultConfig.themeColorCode,
     types: promptConfig.types ?? defaultConfig.types,
     typesAppend: promptConfig.typesAppend ?? defaultConfig.typesAppend,
-    useEmoji: Boolean(emoji) || promptConfig.useEmoji || defaultConfig.useEmoji,
+    useEmoji: Boolean(emoji === "1") || promptConfig.useEmoji || defaultConfig.useEmoji,
     scopes: promptConfig.scopes ?? getEnumList(config?.rules?.["scope-enum"] as any),
     scopeOverrides: promptConfig.scopeOverrides ?? defaultConfig.scopeOverrides,
     scopeFilters: promptConfig.scopeFilters ?? defaultConfig.scopeFilters,
-    enableMultipleScopes: Boolean(checkbox) || promptConfig.enableMultipleScopes || defaultConfig.enableMultipleScopes,
+    enableMultipleScopes: Boolean(checkbox === "1") || promptConfig.enableMultipleScopes || defaultConfig.enableMultipleScopes,
     scopeEnumSeparator: promptConfig.scopeEnumSeparator ?? defaultConfig.scopeEnumSeparator,
     allowCustomScopes: promptConfig.allowCustomScopes ?? !enumRuleIsActive(config?.rules?.["scope-enum"] as any),
     allowEmptyScopes: promptConfig.allowEmptyScopes ?? !emptyRuleIsActive(config?.rules?.["scope-empty"] as any),
@@ -37,6 +37,7 @@ export const generateOptions = (config: UserConfig): CommitizenGitOptions => {
     customScopesAlias: promptConfig.customScopesAlias ?? defaultConfig.customScopesAlias,
     emptyScopesAlias: promptConfig.emptyScopesAlias ?? defaultConfig.emptyScopesAlias,
     upperCaseSubject: promptConfig.upperCaseSubject ?? defaultConfig.upperCaseSubject,
+    markBreakingChangeMode: promptConfig.markBreakingChangeMode ?? defaultConfig.markBreakingChangeMode,
     allowBreakingChanges: promptConfig.allowBreakingChanges ?? defaultConfig.allowBreakingChanges,
     breaklineNumber: getMaxLength(config?.rules?.["body-max-line-length"] as any) === Infinity
       ? promptConfig.breaklineNumber ?? defaultConfig.breaklineNumber

--- a/packages/cz-git/src/generator/question.ts
+++ b/packages/cz-git/src/generator/question.ts
@@ -166,12 +166,21 @@ export const generateQuestions = (options: CommitizenGitOptions, cz: any) => {
       transformer: (input: string) => useThemeCode(input, options.themeColorCode)
     },
     {
+      type: "confirm",
+      name: "markBreaking",
+      message: options.messages?.markBreaking,
+      default: false,
+      when: () => options.markBreakingChangeMode === true
+    },
+    {
       type: "complete-input",
       name: "breaking",
       message: options.messages?.breaking,
       completeValue: options.defaultBody || undefined,
       when: (answers: Answers) => {
-        if (
+        if (options.markBreakingChangeMode === true) {
+          return answers.markBreaking;
+        } else if (
           options.allowBreakingChanges &&
           answers.type &&
           options.allowBreakingChanges.includes(answers.type)

--- a/packages/cz-git/src/shared/types/options.ts
+++ b/packages/cz-git/src/shared/types/options.ts
@@ -50,7 +50,7 @@ export type Answers = {
    * @default: Is any BREAKING CHANGE (add "!" in header) (optional) ?
    * @use need turn on options "markBreakingChangeMode"
    */
-  markBreaking?: string;
+  markBreaking?: string | boolean;
   /**
    * @default: List any BREAKING CHANGES (optional). Use "|" to break new line:\n
    */

--- a/packages/cz-git/src/shared/types/options.ts
+++ b/packages/cz-git/src/shared/types/options.ts
@@ -47,6 +47,11 @@ export type Answers = {
    */
   body?: string;
   /**
+   * @default: Is any BREAKING CHANGE (add "!" in header) (optional) ?
+   * @use need turn on options "markBreakingChangeMode"
+   */
+  markBreaking?: string;
+  /**
    * @default: List any BREAKING CHANGES (optional). Use "|" to break new line:\n
    */
   breaking?: string;
@@ -198,6 +203,13 @@ export interface CommitizenGitOptions {
   upperCaseSubject?: boolean;
 
   /**
+   * @description: Whether to add extra prompt BREAKCHANGE ask. to add an extra "!" to the header
+   * @see: https://cz-git.qbenben.com/recipes/breakingchange
+   * @default: false
+   */
+  markBreakingChangeMode?: boolean;
+
+  /**
    * @description: Allow breaking changes in the included types output box
    * @default: ['feat', 'fix']
    */
@@ -332,6 +344,7 @@ export const defaultConfig = Object.freeze({
      customScope: "Denote the SCOPE of this change:",
      subject: "Write a SHORT, IMPERATIVE tense description of the change:\n",
      body: 'Provide a LONGER description of the change (optional). Use "|" to break new line:\n',
+     markBreaking: 'Is any BREAKING CHANGE (add "!" in header) (optional) ?',
      breaking: 'List any BREAKING CHANGES (optional). Use "|" to break new line:\n',
      footerPrefixsSelect: "Select the ISSUES type of change (optional):",
      customFooterPrefixs: "Input ISSUES prefix:",
@@ -363,6 +376,7 @@ export const defaultConfig = Object.freeze({
    customScopesAlias: "custom",
    emptyScopesAlias: "empty",
    upperCaseSubject: false,
+   markBreakingChangeMode: false,
    allowBreakingChanges: ['feat', 'fix'],
    breaklineNumber: 100,
    breaklineChar: "|",


### PR DESCRIPTION
## Related ISSUE

> Input follow ISSUE URL address

#38 

## Type Of Change

- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 📝 Document (This change requires a documentation update)
- [ ] 🎨 Theme style (Theme style beautification)
- [ ] ⚠  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔨 Workflow (Workflow changes)

## Clear Describe

> A clear and concise description of what update for target.

feat(cz-git): add markBreakingChangeMode options to add extra prompt


## Description

> Please enter detailed relevant motivation, background and implementation ... descriptive information.

it use exclamation (!) to denote breaking change
see: https://www.conventionalcommits.org/en/v1.0.0/#examples

## Test Case

- [x]  add `markBreakingChangeMode` options  testcase

![demo](https://user-images.githubusercontent.com/40693636/174950214-b294413c-b2b4-4e5b-9b8d-38deab9e8485.gif)
