### PR TITLE
fix(cz-git): remove `markBreakingChangeMode` restrictions 

### DIFF
--- a/docs-zh/recipes/breakingchange.md
+++ b/docs-zh/recipes/breakingchange.md
@@ -18,7 +18,7 @@ BREAKING CHANGE: use JavaScript features not available in Node 6.
 ```
 
 ## 使用配置项: `markBreakingChangeMode`
-> 改变 "BREAKINGCHANGE"的提问方式，询问是否需要添加 =="!"== 标识
+> 额外添加 "BREAKINGCHANGE"的提问，询问是否需要添加 =="!"== 标识
 
 ```js{6}
 // .commitlintrc.js
@@ -32,7 +32,7 @@ module.exports = {
 ```
 
 示例:
-![demo](https://user-images.githubusercontent.com/40693636/174950214-b294413c-b2b4-4e5b-9b8d-38deab9e8485.gif)
+![demo](https://user-images.githubusercontent.com/40693636/175775159-710b69c6-ab55-4957-9195-6f963d95ba2e.gif)
 
 ## 使用 commitizen CLI + cz-git
 可以尝试运行命令自动添加标识:

--- a/docs/recipes/breakingchange.md
+++ b/docs/recipes/breakingchange.md
@@ -18,7 +18,7 @@ BREAKING CHANGE: use JavaScript features not available in Node 6.
 ```
 
 ## Use Option: `markBreakingChangeMode`
-> Change "BREAKINGCHANGE" question that if you need to add the =="!"== mark in the header
+> Add extra "BREAKING CHANGE" question that if you need to add the =="!"== mark in the header
 
 ```js{6}
 // .commitlintrc.js
@@ -32,7 +32,7 @@ module.exports = {
 ```
 
 Demo:
-![demo](https://user-images.githubusercontent.com/40693636/174950214-b294413c-b2b4-4e5b-9b8d-38deab9e8485.gif)
+![demo](https://user-images.githubusercontent.com/40693636/175775159-710b69c6-ab55-4957-9195-6f963d95ba2e.gif)
 
 ## Use commitizen CLI + cz-git
 Try running command:

--- a/docs/zh/recipes/breakingchange.md
+++ b/docs/zh/recipes/breakingchange.md
@@ -18,7 +18,7 @@ BREAKING CHANGE: use JavaScript features not available in Node 6.
 ```
 
 ## 使用配置项: `markBreakingChangeMode`
-> 改变 "BREAKINGCHANGE"的提问方式，询问是否需要添加 =="!"== 标识
+> 额外添加 "BREAKINGCHANGE"的提问，询问是否需要添加 =="!"== 标识
 
 ```js{6}
 // .commitlintrc.js
@@ -32,7 +32,7 @@ module.exports = {
 ```
 
 示例:
-![demo](https://user-images.githubusercontent.com/40693636/174950214-b294413c-b2b4-4e5b-9b8d-38deab9e8485.gif)
+![demo](https://user-images.githubusercontent.com/40693636/175775159-710b69c6-ab55-4957-9195-6f963d95ba2e.gif)
 
 ## 使用 commitizen CLI + cz-git
 可以尝试运行命令自动添加标识:

--- a/packages/cz-git/src/generator/question.ts
+++ b/packages/cz-git/src/generator/question.ts
@@ -178,16 +178,14 @@ export const generateQuestions = (options: CommitizenGitOptions, cz: any) => {
       message: options.messages?.breaking,
       completeValue: options.defaultBody || undefined,
       when: (answers: Answers) => {
-        if (options.markBreakingChangeMode === true) {
-          return answers.markBreaking;
-        } else if (
+        if (
           options.allowBreakingChanges &&
           answers.type &&
           options.allowBreakingChanges.includes(answers.type)
         ) {
           return true;
         } else {
-          return false;
+          return answers.markBreaking || false;
         }
       },
       transformer: (input: string) => useThemeCode(input, options.themeColorCode)


### PR DESCRIPTION
## Related ISSUE

> Input follow ISSUE URL address

<!-- link #33 -->
#38 

## Type Of Change

- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 📝 Document (This change requires a documentation update)
- [ ] 🎨 Theme style (Theme style beautification)
- [ ] ⚠  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔨 Workflow (Workflow changes)

## Clear Describe

> A clear and concise description of what update for target.

<!-- 
input summary. e.g:
- feat: add output emoji
- docs: add `emoji` option document
-->

fix(cz-git): remove `markBreakingChangeMode` restrictions on BREAKINGCHANGE footer

## Description

> Please enter detailed relevant motivation, background and implementation ... descriptive information.
you can omit the ! when there is a BREAKING CHANGE: footer and vice versa. See the [examples](https://www.conventionalcommits.org/en/v1.0.0/#examples) on site:
