### PR TITLE
fix(cz-git): fix empty custom output '___CUSTOM___' value

### DIFF
--- a/packages/cz-git/__tests__/generateMessage.test.ts
+++ b/packages/cz-git/__tests__/generateMessage.test.ts
@@ -31,6 +31,28 @@ describe('generateMessage()', () => {
       }
       expect(generateMessage(answers, options)).toEqual('feat(app): add a new feature')
     })
+
+    test('custom value scope should be output custom value', () => {
+      const options = {}
+      const answers = {
+        type: 'feat',
+        scope: '___CUSTOM___',
+        customScope: 'app',
+        subject: 'add a new feature',
+      }
+      expect(generateMessage(answers, options)).toEqual('feat(app): add a new feature')
+    })
+
+    test('empty custom scope value scope should be output empty value', () => {
+      const options = {}
+      const answers = {
+        type: 'feat',
+        scope: '___CUSTOM___',
+        customScope: '',
+        subject: 'add a new feature',
+      }
+      expect(generateMessage(answers, options)).toEqual('feat: add a new feature')
+    })
   })
 
   describe('subject', () => {
@@ -92,10 +114,7 @@ describe('generateMessage()', () => {
         body: 'test breaklineNumber test breaklineNumber',
       }
       expect(generateMessage(answers, options)).toEqual(
-        `feat(app): add a new feature
-
-test breaklineNumber
-test breaklineNumber`,
+        'feat(app): add a new feature\n\ntest breaklineNumber\ntest breaklineNumber',
       )
     })
 
@@ -127,6 +146,30 @@ test breaklineNumber`,
   })
 
   describe('footer', () => {
+    test('custom footerPrefix should be output custom value', () => {
+      const options = {}
+      const answers = {
+        type: 'feat',
+        subject: 'add a new feature',
+        footerPrefix: '___CUSTOM___',
+        customFooterPrefixs: 'CLOSED',
+        footer: '#1',
+      }
+      expect(generateMessage(answers, options)).toEqual('feat: add a new feature\n\nCLOSED #1')
+    })
+
+    test('empty custom footerPrefix value scope should be output empty value', () => {
+      const options = {}
+      const answers = {
+        type: 'feat',
+        subject: 'add a new feature',
+        footerPrefix: '___CUSTOM___',
+        customFooterPrefixs: '',
+        footer: '#1',
+      }
+      expect(generateMessage(answers, options)).toEqual('feat: add a new feature\n\n#1')
+    })
+
     test('both hit single footerPrefix should be output right', () => {
       const options = {
         types: [{ value: 'feat', name: 'feat:     A new feature' }],
@@ -139,11 +182,7 @@ test breaklineNumber`,
         subject: 'add a new feature',
         footer: '#12',
       }
-      expect(generateMessage(answers, options)).toEqual(
-        `feat: add a new feature
-
-closed #12`,
-      )
+      expect(generateMessage(answers, options)).toEqual('feat: add a new feature\n\nclosed #12')
     })
 
     test('both hit single footerPrefix but not footer should be not output', () => {
@@ -175,11 +214,7 @@ closed #12`,
         subject: 'add a new feature',
         footer: '#12',
       }
-      expect(generateMessage(answers, options)).toEqual(
-        `feat(app): add a new feature
-
-closed #12`,
-      )
+      expect(generateMessage(answers, options)).toEqual('feat(app): add a new feature\n\nclosed #12')
     })
   })
 })

--- a/packages/cz-git/src/generator/message.ts
+++ b/packages/cz-git/src/generator/message.ts
@@ -45,6 +45,12 @@ const getSingleParams = (answers: Answers, options: CommitizenGitOptions) => {
   return mapping
 }
 
+const getCustomValue = (originVal?: string | string [], customVal?: string) => {
+  if (Array.isArray(originVal))
+    return originVal
+  return originVal !== '___CUSTOM___' ? originVal || '' : customVal || ''
+}
+
 const addType = (type: string, colorize?: boolean) => (colorize ? style.green(type) : type)
 
 const addScope = (scope?: string, colorize?: boolean) => {
@@ -109,9 +115,8 @@ export const generateMessage = (
   }
 
   const { customScope, customFooterPrefixs } = answers
-  answers.scope = (answers.scope === '___CUSTOM___' && customScope) || answers.scope
-  answers.footerPrefix
-    = (answers.footerPrefix === '___CUSTOM___' && customFooterPrefixs) || answers.footerPrefix
+  answers.scope = getCustomValue(answers.scope, customScope)
+  answers.footerPrefix = getCustomValue(answers.footerPrefix, customFooterPrefixs) as string
 
   const { singleScope, singeIssuePrefix } = getSingleParams(answers, options)
   const scope = Array.isArray(answers.scope)


### PR DESCRIPTION
## Related ISSUE

> Input follow ISSUE URL address

<!-- link #33 -->
link #55 
## Type Of Change

- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📝 Document (This change requires a documentation update)
- [ ] 🎨 Theme style (Theme style beautification)
- [ ] ⚠  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔨 Workflow (Workflow changes)

## Clear Describe

> A clear and concise description of what update for target.

<!-- 
input summary. e.g:
- feat: add output emoji
- docs: add `emoji` option document
-->
- fix(cz-git): fix empty custom output '___CUSTOM___' value

## Description

> Please enter detailed relevant motivation, background and implementation ... descriptive information.

After bump the `inquirer` dependency, it is not supported to output a prompt value with the same name. 
Although it has been processed, the `build message` has not been correctly judged

<img width="1920" alt="_b16b0bcc-53a9-4a99-b3ef-8576636945ad" src="https://user-images.githubusercontent.com/40693636/184480726-d3a1ab6f-a1ae-4973-b928-2c5fa2df2321.png">

## Test Case
- [x] added
