### PR TITLE
feat(cz-git): allow search `type[name]` | allow custom finally message format

### DIFF
--- a/.commitlintrc.cjs
+++ b/.commitlintrc.cjs
@@ -12,7 +12,8 @@ const packages = fg.sync('*', { cwd: 'packages/@cz-git', onlyDirectories: true }
 
 // custom add Co-authored-by
 const coAuthoredBy
-  = `Co-authored-by: ${
+  = '\n\n'
+  + `Co-authored-by: ${
      execSync('git config user.name').toString().replace(/(\r\n\t|\n|\r\t)/g, '')
      } <${
      execSync('git config user.email').toString().replace(/(\r\n\t|\n|\r\t)/g, '')
@@ -29,12 +30,12 @@ module.exports = {
   prompt: {
     // @see: https://github.com/Zhengqbbb/cz-git#options
     alias: {
-      'b': 'chore: bump dependencies',
-      'c': 'chore: update config files',
-      'f': 'docs: fix typos',
-      ':': 'docs: update README',
-      'table:data': 'chore: :hammer: update project using table data',
-      'table:docs': 'docs: update project using table',
+      'b': 'chore: bump dependencies' + coAuthoredBy,
+      'c': 'chore: update config files' + coAuthoredBy,
+      'f': 'docs: fix typos' + coAuthoredBy,
+      ':': 'docs: update README' + coAuthoredBy,
+      'table:data': 'chore: :hammer: update project using table data' + coAuthoredBy,
+      'table:docs': 'docs: update project using table' + coAuthoredBy,
     },
     themeColorCode: '38;5;043',
     issuePrefixs: [
@@ -43,8 +44,6 @@ module.exports = {
     ],
     customIssuePrefixsAlign: !issue ? 'top' : 'bottom',
     defaultIssues: !issue ? '' : `#${issue}`,
-    formatMessageCB: ({ defaultMessage }) => {
-      return `${defaultMessage}\n\n${coAuthoredBy}`
-    },
+    formatMessageCB: ({ defaultMessage }) => defaultMessage + coAuthoredBy,
   },
 }

--- a/.commitlintrc.cjs
+++ b/.commitlintrc.cjs
@@ -1,14 +1,22 @@
 const { execSync } = require('child_process')
 const fg = require('fast-glob')
 
-// @description: git branch name = feature/cli_33 => auto get defaultIssues = #33
+// git branch name = feature/cli_33 => auto get defaultIssues = #33
 const issue = execSync('git rev-parse --abbrev-ref HEAD')
   .toString()
   .trim()
   .split('_')[1]
 
-// @description: monorepo dynamic get name
+// monorepo dynamic get name
 const packages = fg.sync('*', { cwd: 'packages/@cz-git', onlyDirectories: true })
+
+// custom add Co-authored-by
+const coAuthoredBy
+  = `Co-authored-by: ${
+     execSync('git config user.name').toString().replace(/(\r\n\t|\n|\r\t)/g, '')
+     } <${
+     execSync('git config user.email').toString().replace(/(\r\n\t|\n|\r\t)/g, '')
+     }>`
 
 /** @type {import('cz-git').UserConfig} */
 module.exports = {
@@ -35,5 +43,8 @@ module.exports = {
     ],
     customIssuePrefixsAlign: !issue ? 'top' : 'bottom',
     defaultIssues: !issue ? '' : `#${issue}`,
+    formatMessageCB: ({ defaultMessage }) => {
+      return `${defaultMessage}\n\n${coAuthoredBy}`
+    },
   },
 }

--- a/packages/@cz-git/plugin-loader/src/index.ts
+++ b/packages/@cz-git/plugin-loader/src/index.ts
@@ -39,8 +39,8 @@ export const loader = async (options: LoaderOptions) => {
   return result ?? null
 }
 
-function executable<T>(config: Config<T>): config is ExectableConfig<T> {
-  return typeof config === 'function'
+function executable<T>(config: Config<T>, name: string): config is ExectableConfig<T> {
+  return typeof config === 'function' && !name.endsWith('CB')
 }
 
 async function configExecute<T>(
@@ -51,7 +51,7 @@ async function configExecute<T>(
     return null
 
   const [name, config] = configItem as [string, Config<T>]
-  const fn = executable(config) ? config : async () => config
+  const fn = executable(config, name) ? config : async () => config
   return [name, await fn()]
 }
 

--- a/packages/cz-git/__tests__/generateMessage.test.ts
+++ b/packages/cz-git/__tests__/generateMessage.test.ts
@@ -217,4 +217,31 @@ describe('generateMessage()', () => {
       expect(generateMessage(answers, options)).toEqual('feat(app): add a new feature\n\nclosed #12')
     })
   })
+
+  describe('message', () => {
+    test('custom emoji message format callback should be output right', () => {
+      const options = {
+        types: [{ value: 'feat', name: 'feat:     A new feature', emoji: ':sparkles:' }],
+        useEmoji: true,
+        formatMessageCB: ({ emoji, scope, subject }) => {
+          return scope
+            ? `${emoji}(${scope}): ${subject}`
+            : `${emoji} ${subject}`
+        },
+      }
+
+      let answers: any = {
+        type: 'feat',
+        subject: 'add a new feature',
+      }
+      expect(generateMessage(answers, options)).toEqual(':sparkles: add a new feature')
+
+      answers = {
+        type: 'feat',
+        scope: 'app',
+        subject: 'add a new feature',
+      }
+      expect(generateMessage(answers, options)).toEqual(':sparkles:(app): add a new feature')
+    })
+  })
 })

--- a/packages/cz-git/src/generator/message.ts
+++ b/packages/cz-git/src/generator/message.ts
@@ -145,8 +145,8 @@ export const generateMessage = (
   const subject = addSubject(answers.subject, colorize)
 
   const defaultHeader
-    = `${`${addEmoji(emoji, 'left', options.emojiAlign)}${type}${scope ? `(${scope})` : ''}${markBreaking}`}: ${
-        addEmoji(emoji, 'center', options.emojiAlign)}${subject}${addEmoji(emoji, 'right', options.emojiAlign)}`
+    = `${`${addEmoji(emoji, 'left', options.emojiAlign)}${type}${scope ? `(${scope})` : ''}${markBreaking}`
+      }: ${addEmoji(emoji, 'center', options.emojiAlign)}${subject}${addEmoji(emoji, 'right', options.emojiAlign)}`
 
   const body = wrap(answers.body ?? '', wrapOptions)
   const breaking = wrap(answers.breaking ?? '', wrapOptions)

--- a/packages/cz-git/src/generator/message.ts
+++ b/packages/cz-git/src/generator/message.ts
@@ -57,7 +57,7 @@ const addScope = (scope?: string, colorize?: boolean) => {
   if (!scope)
     return ''
   scope = colorize ? style.yellow(scope) : scope
-  return `(${scope?.trim()})`
+  return scope?.trim()
 }
 
 const addBreakchangeMark = (markBreaking?: string | boolean, colorize?: boolean) => {
@@ -143,14 +143,11 @@ export const generateMessage = (
   const scope = addScope(singleScope || scopeSource, colorize)
   const markBreaking = addBreakchangeMark(answers.markBreaking, colorize)
   const subject = addSubject(answers.subject, colorize)
-  const defaultHeader = `${addEmoji(emoji, 'left', options.emojiAlign)
-    + type
-    + scope
-    + markBreaking
-    }: ${addEmoji(emoji, 'center', options.emojiAlign)
-    + subject
-    + addEmoji(emoji, 'right', options.emojiAlign)
-  }`
+
+  const defaultHeader
+    = `${`${addEmoji(emoji, 'left', options.emojiAlign)}${type}${scope ? `(${scope})` : ''}${markBreaking}`}: ${
+        addEmoji(emoji, 'center', options.emojiAlign)}${subject}${addEmoji(emoji, 'right', options.emojiAlign)}`
+
   const body = wrap(answers.body ?? '', wrapOptions)
   const breaking = wrap(answers.breaking ?? '', wrapOptions)
   const footerSuffix = wrap(answers.footer ?? '', wrapOptions)

--- a/packages/cz-git/src/generator/option.ts
+++ b/packages/cz-git/src/generator/option.ts
@@ -24,6 +24,7 @@ export const generateOptions = (config: UserConfig): CommitizenGitOptions => {
     themeColorCode: ___X_CMD_THEME_COLOR_CODE || promptConfig.themeColorCode || defaultConfig.themeColorCode,
     types: promptConfig.types ?? defaultConfig.types,
     typesAppend: promptConfig.typesAppend ?? defaultConfig.typesAppend,
+    typesSearchValueKey: promptConfig.typesSearchValueKey ?? defaultConfig.typesSearchValueKey,
     useEmoji: Boolean(emoji === '1') || promptConfig.useEmoji || defaultConfig.useEmoji,
     emojiAlign: promptConfig.emojiAlign || defaultConfig.emojiAlign,
     scopes: promptConfig.scopes ?? getEnumList(config?.rules?.['scope-enum'] as any),

--- a/packages/cz-git/src/generator/option.ts
+++ b/packages/cz-git/src/generator/option.ts
@@ -61,5 +61,6 @@ export const generateOptions = (config: UserConfig): CommitizenGitOptions => {
     defaultBody: promptConfig.defaultBody ?? defaultConfig.defaultBody,
     defaultFooterPrefix: promptConfig.defaultFooterPrefix ?? defaultConfig.defaultFooterPrefix,
     defaultIssues: promptConfig.defaultIssues ?? defaultConfig.defaultIssues,
+    formatMessageCB: promptConfig.formatMessageCB ?? defaultConfig.formatMessageCB,
   }
 }

--- a/packages/cz-git/src/generator/question.ts
+++ b/packages/cz-git/src/generator/question.ts
@@ -39,7 +39,10 @@ export const generateQuestions = (options: CommitizenGitOptions, cz: any) => {
           options.types?.concat(options.typesAppend || []) || [],
           options.defaultType,
         )
-        return fuzzyFilter(input, typeSource, 'value')
+        const searchTarget = options.typesSearchValueKey
+          ? 'value'
+          : 'name'
+        return fuzzyFilter(input, typeSource, searchTarget)
       },
     },
     {

--- a/packages/cz-git/src/shared/types/options.ts
+++ b/packages/cz-git/src/shared/types/options.ts
@@ -139,6 +139,12 @@ export interface CommitizenGitOptions {
   typesAppend?: TypesOption[]
 
   /**
+   * @description: default types list fuzzy search types `value` options. if choose `false` will search `name` options
+   * @default: true
+   */
+  typesSearchValueKey?: boolean
+
+  /**
    * @description: Use emoji ？| it will be use typesOption.emoji code
    * @default: false
    */
@@ -380,6 +386,7 @@ export const defaultConfig = Object.freeze({
     { value: 'revert', name: 'revert:   Reverts a previous commit', emoji: ':rewind:' },
   ],
   typesAppend: [],
+  typesSearchValueKey: true,
   themeColorCode: '',
   useEmoji: false,
   emojiAlign: 'center',

--- a/packages/cz-git/src/shared/types/options.ts
+++ b/packages/cz-git/src/shared/types/options.ts
@@ -101,16 +101,45 @@ export interface TypesOption extends Option {
   emoji?: string
 }
 
+/**
+ * provide subdivides each message part
+ */
 export interface CommitMessageOptions {
+  /**
+   * @description: choose type list value
+   * @example: 'feat'
+   */
   type: string
+  /**
+   * @description: choose or custom scope value
+   * @example: 'app'
+   */
   scope: string
+  /**
+   * @description: choose type list emoji code. need turn on `useEmoji` options
+   * @example: ':sparkles:'
+   */
   emoji: string
+  /**
+   * @description: express is a breaking change message
+   * @example `!`
+   */
   markBreaking: string
+  /**
+   * @description: input subject
+   */
   subject: string
+  /**
+   * @description: base Angular format default header
+   * @example `feat(app): add a feature`
+   */
   defaultHeader: string
   body: string
   breaking: string
   footer: string
+  /**
+   * @description: base Angular format default all message
+   */
   defaultMessage: string
 }
 
@@ -369,6 +398,11 @@ export interface CommitizenGitOptions {
    */
   defaultIssues?: string
 
+  /**
+   * @description: provide user custom finally message, can use the callback to change format
+   * @param CommitMessageOptions: provide subdivides each message part
+   * @default: ({ defaultMessage }) => defaultMessage
+   */
   formatMessageCB?: (messageMod: CommitMessageOptions) => string
 }
 

--- a/packages/cz-git/src/shared/types/options.ts
+++ b/packages/cz-git/src/shared/types/options.ts
@@ -101,6 +101,19 @@ export interface TypesOption extends Option {
   emoji?: string
 }
 
+export interface CommitMessageOptions {
+  type: string
+  scope: string
+  emoji: string
+  markBreaking: string
+  subject: string
+  defaultHeader: string
+  body: string
+  breaking: string
+  footer: string
+  defaultMessage: string
+}
+
 export interface CommitizenGitOptions {
   /**
    * @description: define commonly used commit message alias
@@ -355,6 +368,8 @@ export interface CommitizenGitOptions {
    * @example: When you want to use default, just keybord <Enter> it
    */
   defaultIssues?: string
+
+  formatMessageCB?: (messageMod: CommitMessageOptions) => string
 }
 
 export const defaultConfig = Object.freeze({
@@ -422,4 +437,5 @@ export const defaultConfig = Object.freeze({
   defaultSubject: '',
   defaultFooterPrefix: '',
   defaultIssues: '',
+  formatMessageCB: undefined,
 } as CommitizenGitOptions)


### PR DESCRIPTION
## Related ISSUE

> Input follow ISSUE URL address

<!-- link #33 -->

link #57 

## Type Of Change

- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📝 Document (This change requires a documentation update)
- [ ] 🎨 Theme style (Theme style beautification)
- [ ] ⚠  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔨 Workflow (Workflow changes)

## Clear Describe

> A clear and concise description of what update for target.

<!-- 
input summary. e.g:
- feat: add output emoji
- docs: add `emoji` option document
-->

- feat(cz-git): support types fuzzy search types[name] options
- feat(cz-git): add formatMessageCB can custom finally commit message

## Description

> Please enter detailed relevant motivation, background and implementation ... descriptive information.

### allow search `type[name]`

Add `typesSearchValueKey` option
- default types list fuzzy search types `value` options.
- if choose `false` will search `name` options

### allow custom finally message format

Add `formatMessageCB` option that is a callback function
provide user define fn and fn's param to custom finally commit message

```ts
/**
   * @description: provide user custom finally message, can use the callback to change format
   * @param CommitMessageOptions: provide subdivides each message part
   * @default: ({ defaultMessage }) => defaultMessage
   */
 interface formatMessageCB?: (messageMod: CommitMessageOptions) => string

/**
 * provide subdivides each message part
 */
export interface CommitMessageOptions {
  /**
   * @description: choose type list value
   * @example: 'feat'
   */
  type: string
  /**
   * @description: choose or custom scope value
   * @example: 'app'
   */
  scope: string
  /**
   * @description: choose type list emoji code. need turn on `useEmoji` options
   * @example: ':sparkles:'
   */
  emoji: string
  /**
   * @description: express is a breaking change message
   * @example `!`
   */
  markBreaking: string
  /**
   * @description: input subject
   */
  subject: string
  /**
   * @description: base Angular format default header
   * @example `feat(app): add a feature`
   */
  defaultHeader: string
  body: string
  breaking: string
  footer: string
  /**
   * @description: base Angular format default all message
   */
  defaultMessage: string
}
```


## Test Case

> Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test case.

- [x] added `formatMessageCB` testcase


