### PR TITLE
feat(cli): support GPG sign commit message

### DIFF
--- a/packages/cli/src/generator/czg.ts
+++ b/packages/cli/src/generator/czg.ts
@@ -28,6 +28,7 @@ export const czg = (version: string, argvs: CzgitParseArgs, environment: any = {
       injectEnvFlag('break', argvs.czgitArgs.subCommand?.break)
       injectEnvFlag('emoji', argvs.czgitArgs.subCommand?.emoji)
       injectEnvFlag('checkbox', argvs.czgitArgs.subCommand?.checkbox)
+      injectEnvFlag('CzCommitSignGPG', argvs.czgitArgs.subCommand?.gpg)
       injectEnvValue('cz_alias', argvs.czgitArgs.flag?.alias)
 
       console.log(`czg@${version}\n`)

--- a/packages/cli/src/generator/help.ts
+++ b/packages/cli/src/generator/help.ts
@@ -20,6 +20,7 @@ ${style.yellow('SUBCOMMAND:')}
     ${style.cyan('break')}          ${style.red('Turn on BREAKING CHANGE mode, Add ! mark on header')}
     ${style.cyan('emoji')}          ${style.red('Turn on output message with emoji mode')}
     ${style.cyan('checkbox')}       ${style.red('Turn on scope checkbox mode')}
+    ${style.cyan('gpg')}            ${style.red('Turn on use GPG sign commit message')}
     
 ${style.yellow('OPTIONS:')}
     ${style.cyan('--config')}       ${style.red('Specify the configuration file to use')}

--- a/packages/cli/src/shared/types/czg.ts
+++ b/packages/cli/src/shared/types/czg.ts
@@ -32,7 +32,7 @@ export interface InitFlag {
   yes?: boolean
 }
 
-export type CzgitSubCommandList = 'init' | 'emoji' | 'checkbox' | 'break'
+export type CzgitSubCommandList = 'init' | 'emoji' | 'checkbox' | 'break' | 'gpg'
 export interface CzgitSubCommand {
   /** option: init */
   init?: boolean
@@ -42,6 +42,8 @@ export interface CzgitSubCommand {
   checkbox?: boolean
   /** subcmd: break */
   break?: boolean
+  /** subcmd: gpg */
+  gpg?: boolean
 }
 
 /**

--- a/packages/cli/src/shared/utils/git.ts
+++ b/packages/cli/src/shared/utils/git.ts
@@ -63,7 +63,9 @@ export const gitCommit = (
    * use `git cimmit -m "...message..."`
    */
   if (!options.hookMode) {
-    const args = ['commit', '-m', dedent(message), ...(options.args || [])]
+    const args = process.env.CzCommitSignGPG !== '1'
+      ? ['commit', '-m', dedent(message), ...(options.args || [])]
+      : ['commit', '-S', '-m', dedent(message), ...(options.args || [])]
     const child = spawn('git', args, {
       cwd: repoPath,
       stdio: options.quiet ? 'ignore' : 'inherit',

--- a/packages/cli/src/shared/utils/parse.ts
+++ b/packages/cli/src/shared/utils/parse.ts
@@ -81,6 +81,7 @@ export const resovleArgs = (argv: string[]): CzgitParseArgs => {
       result = resovleSubCmd(parseArgv._[i], 'emoji', result)
       result = resovleSubCmd(parseArgv._[i], 'checkbox', result)
       result = resovleSubCmd(parseArgv._[i], 'break', result)
+      result = resovleSubCmd(parseArgv._[i], 'gpg', result)
       // resolve alias
       result = resovleAlias(parseArgv._[i], result)
     }

--- a/packages/cz-git/src/generator/option.ts
+++ b/packages/cz-git/src/generator/option.ts
@@ -61,6 +61,7 @@ export const generateOptions = (config: UserConfig): CommitizenGitOptions => {
     defaultBody: promptConfig.defaultBody ?? defaultConfig.defaultBody,
     defaultFooterPrefix: promptConfig.defaultFooterPrefix ?? defaultConfig.defaultFooterPrefix,
     defaultIssues: promptConfig.defaultIssues ?? defaultConfig.defaultIssues,
+    useCommitSignGPG: promptConfig.useCommitSignGPG ?? defaultConfig.useCommitSignGPG,
     formatMessageCB: promptConfig.formatMessageCB ?? defaultConfig.formatMessageCB,
   }
 }

--- a/packages/cz-git/src/index.ts
+++ b/packages/cz-git/src/index.ts
@@ -23,6 +23,8 @@ export const prompter = (
   configLoader({ configPath }).then((config) => {
     const options = generateOptions(config)
 
+    if (options.useCommitSignGPG)
+      process.env.CzCommitSignGPG = '1'
     if ('cz_alias' in process.env) {
       commit(getAliasMessage(options, process.env.cz_alias))
       return

--- a/packages/cz-git/src/shared/types/options.ts
+++ b/packages/cz-git/src/shared/types/options.ts
@@ -399,6 +399,14 @@ export interface CommitizenGitOptions {
   defaultIssues?: string
 
   /**
+   * @description: Whether to use GPG sign commit message (git commit -S -m)
+   * @note the options only support `czg` cz-git cli and no support git hooks mode
+   * @usage_see https://github.com/Zhengqbbb/cz-git/issues/58
+   * @default: false
+   */
+  useCommitSignGPG?: boolean
+
+  /**
    * @description: provide user custom finally message, can use the callback to change format
    * @param CommitMessageOptions: provide subdivides each message part
    * @default: ({ defaultMessage }) => defaultMessage
@@ -471,5 +479,6 @@ export const defaultConfig = Object.freeze({
   defaultSubject: '',
   defaultFooterPrefix: '',
   defaultIssues: '',
+  useCommitSignGPG: false,
   formatMessageCB: undefined,
 } as CommitizenGitOptions)


### PR DESCRIPTION
## Related ISSUE

> Input follow ISSUE URL address

link #58

<!-- link #33 -->

## Type Of Change

- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📝 Document (This change requires a documentation update)
- [ ] 🎨 Theme style (Theme style beautification)
- [ ] ⚠  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔨 Workflow (Workflow changes)

## Clear Describe

> A clear and concise description of what update for target.

<!-- 
input summary. e.g:
- feat: add output emoji
- docs: add `emoji` option document
-->

feat(cli): support GPG sign commit message

## Description

1. can turn on option `useCommitSignGPG`
2. run command `czg gpg`: no-configure use GPG sign commit message

## About GPG sign
See:

#### what is GPG and how to set GPG sign
https://withblue.ink/2020/05/17/how-and-why-to-sign-git-commits.html

#### github docs link:
https://docs.github.com/cn/articles/generating-a-new-gpg-key
https://docs.github.com/articles/signing-commits-using-gpg

#### gitlab docs link:
https://docs.gitlab.com/ee/user/project/repository/gpg_signed_commits/

#### gitee docs link:
https://gitee.com/help/articles/4248#article-header0



