### PR TITLE
fix(cz-git,czg): add ignore commitlint warning max length rule

### DIFF
--- a/packages/cz-git/src/generator/message.ts
+++ b/packages/cz-git/src/generator/message.ts
@@ -5,7 +5,7 @@
  */
 
 import { style } from '@cz-git/inquirer'
-import { getCurrentScopes, handleStandardScopes, isSingleItem, wrap } from '../shared'
+import { getCurrentScopes, isSingleItem, parseStandardScopes, wrap } from '../shared'
 import type { Answers, CommitizenGitOptions } from '../shared'
 
 export const getAliasMessage = (config: CommitizenGitOptions, alias?: string) => {
@@ -27,7 +27,7 @@ const getSingleParams = (answers: Answers, options: CommitizenGitOptions) => {
     singleScope: '',
     singeIssuePrefix: '',
   }
-  const scopeList = handleStandardScopes(
+  const scopeList = parseStandardScopes(
     getCurrentScopes(options.scopes, options.scopeOverrides, answers.type),
   )
   if (isSingleItem(options.allowCustomScopes, options.allowEmptyScopes, scopeList))

--- a/packages/cz-git/src/generator/option.ts
+++ b/packages/cz-git/src/generator/option.ts
@@ -11,6 +11,7 @@ import {
   getEnumList,
   getMaxLength,
   getMinLength,
+  ruleIsWarning,
 } from '../shared'
 import type { CommitizenGitOptions, UserConfig } from '../shared'
 
@@ -54,6 +55,9 @@ export const generateOptions = (config: UserConfig): CommitizenGitOptions => {
     confirmColorize: promptConfig.confirmColorize ?? defaultConfig.confirmColorize,
     maxHeaderLength: promptConfig.maxHeaderLength ?? getMaxLength(config?.rules?.['header-max-length'] as any),
     maxSubjectLength: promptConfig.maxSubjectLength ?? getMaxLength(config?.rules?.['subject-max-length'] as any),
+    isIgnoreCheckMaxSubjectLength: promptConfig.isIgnoreCheckMaxSubjectLength
+      || ruleIsWarning(config?.rules?.['subject-max-length'] as any)
+      || ruleIsWarning(config?.rules?.['header-max-length'] as any),
     minSubjectLength: promptConfig.minSubjectLength ?? getMinLength(config?.rules?.['subject-min-length'] as any),
     defaultType: promptConfig.defaultType ?? defaultConfig.defaultType,
     defaultScope: promptConfig.defaultScope ?? defaultConfig.defaultScope,

--- a/packages/cz-git/src/shared/types/options.ts
+++ b/packages/cz-git/src/shared/types/options.ts
@@ -354,6 +354,14 @@ export interface CommitizenGitOptions {
   maxSubjectLength?: number
 
   /**
+   * @description: Is not strict subject rule. Just provide prompt word length warning.
+   * Effected maxHeader and maxSubject commlitlint
+   * @example [1, 'always', 80] 1: mean warning. will be true
+   * @default: false
+   */
+  isIgnoreCheckMaxSubjectLength?: boolean
+
+  /**
    * @description: Force set header width.
    * @note it auto check rule "subject-min-length" set the option with `@commitlint`.
    * @use when you not use commitlint
@@ -470,6 +478,7 @@ export const defaultConfig = Object.freeze({
   confirmColorize: true,
   maxHeaderLength: Infinity,
   maxSubjectLength: Infinity,
+  isIgnoreCheckMaxSubjectLength: false,
   minSubjectLength: 0,
   scopeOverrides: undefined,
   scopeFilters: ['.DS_Store'],

--- a/packages/cz-git/src/shared/utils/rule.ts
+++ b/packages/cz-git/src/shared/utils/rule.ts
@@ -23,6 +23,19 @@ export function ruleIsDisabled(rule: Rule): rule is Readonly<[RuleConfigSeverity
 }
 
 /**
+ * @description: rule is Warning
+ * @example: ruleIsDisabled([0]) => false
+ * @example: ruleIsDisabled([1]) => true
+ * @example: ruleIsDisabled([2]) => false
+ */
+export function ruleIsWarning(rule?: Rule): rule is Readonly<[RuleConfigSeverity.Disabled]> {
+  if (rule && Array.isArray(rule) && rule[0] === RuleConfigSeverity.Warning)
+    return true
+
+  return false
+}
+
+/**
  * @description: rule is use
  * @example: ruleIsActive([0]) => false
  * @example: ruleIsActive([2]) => true
@@ -51,7 +64,7 @@ export function ruleIsNotApplicable(
 }
 
 /**
- * @description: rule is can ignore
+ * @description: rule is not can be ignore
  */
 export function ruleIsApplicable(
   rule: Rule,


### PR DESCRIPTION
## Related ISSUE

> Input follow ISSUE URL address

<!-- link #33 -->

#71 

## Type Of Change

- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📝 Document (This change requires a documentation update)
- [x] 🎨 Theme style (Theme style beautification)
- [ ] ⚠  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔨 Workflow (Workflow changes)

## Clear Describe

> A clear and concise description of what update for target.

- fix(cz-git): add ignore commitlint warning max length rule
<!-- 
input summary. e.g:
- feat: add output emoji
- docs: add `emoji` option document
-->

## Description

> Please enter detailed relevant motivation, background and implementation ... descriptive information.

In `commitlint` like `'subject-max-length': [1, 'always', 72]`
the array `1` mean warning.commitlint not prevent commit.
so that `cz-git` will just provide prompt expect words msg.


## Test Case

> Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test case.

<img width="1042" alt="image" src="https://user-images.githubusercontent.com/40693636/196086428-c8680697-09f4-4b07-9468-262fb92becca.png">