### PR TITLE
feat(cz-git,czg): add modify message with prompt on AI confirm

### DIFF
--- a/packages/cz-git/src/generator/api.ts
+++ b/packages/cz-git/src/generator/api.ts
@@ -1,3 +1,4 @@
+import url from 'url'
 import { style } from '@cz-git/inquirer'
 import HttpsProxyAgent from 'https-proxy-agent'
 // @ts-expect-error
@@ -16,7 +17,8 @@ export async function fetchOpenAIMessage(options: CommitizenGitOptions, prompt: 
   const httpProxy = options.apiProxy || process.env.https_proxy || process.env.all_proxy || process.env.ALL_PROXY || process.env.http_proxy
   let agent: any
   if (httpProxy) {
-    // const proxyUrl = url.parse(httpProxy)
+    // eslint-disable-next-line n/no-deprecated-api
+    const proxyUrl = url.parse(httpProxy)
     // @ts-expect-error
     agent = new HttpsProxyAgent(proxyUrl)
     agent.path = agent?.pathname

--- a/packages/cz-git/src/generator/message.ts
+++ b/packages/cz-git/src/generator/message.ts
@@ -212,6 +212,6 @@ function generateSubjectDefaultPrompt(
   if (!maxSubjectLength || maxSubjectLength === Infinity || maxSubjectLength > 90)
     maxSubjectLength = 65
 
-  return `Write an insightful and concise Git commit message in the present tense for the following Git diff code, without any prefixes. Note that this sentence should never exceed ${maxSubjectLength} characters in length.: \n\`\`\`diff\n${diff}\n\`\`\``
+  return `Write an insightful and concise Git commit message in the present tense for the following Git diff code, without any prefixes. Note that this sentence must never exceed ${maxSubjectLength} characters in length!! : \n\`\`\`diff\n${diff}\n\`\`\``
 }
 /** EndSection: */

--- a/packages/cz-git/src/generator/question.ts
+++ b/packages/cz-git/src/generator/question.ts
@@ -13,6 +13,7 @@ import {
   isSingleItem,
   log,
   parseStandardScopes,
+  resolveDefaultType,
   resolveListItemPinTop,
   resovleCustomListTemplate,
   useThemeCode,
@@ -50,8 +51,9 @@ export const generateQuestions = (options: CommitizenGitOptions, cz: any) => {
       separator: options.scopeEnumSeparator,
       source: (answer: Answers, input: string) => {
         let scopeSource: Option[] = []
+        const _answerType = resolveDefaultType(options, answer)
         scopeSource = parseStandardScopes(
-          getCurrentScopes(options.scopes, options.scopeOverrides, answer.type),
+          getCurrentScopes(options.scopes, options.scopeOverrides, _answerType),
         )
         scopeSource = resovleCustomListTemplate(
           scopeSource,
@@ -79,11 +81,12 @@ export const generateQuestions = (options: CommitizenGitOptions, cz: any) => {
           return input.length !== 0 ? true : style.red('[ERROR] scope is required')
       },
       when: (answer: Answers) => {
+        const _answerType = resolveDefaultType(options, answer)
         return !isSingleItem(
           options.allowCustomScopes,
           options.allowEmptyScopes,
           parseStandardScopes(
-            getCurrentScopes(options.scopes, options.scopeOverrides, answer.type),
+            getCurrentScopes(options.scopes, options.scopeOverrides, _answerType),
           ),
         )
       },
@@ -119,7 +122,8 @@ export const generateQuestions = (options: CommitizenGitOptions, cz: any) => {
           log('err', 'Error [Subject Length] Option')
           return false
         }
-        const maxSubjectLength = getMaxSubjectLength(answers.type, answers.scope, options)
+        const _answerType = resolveDefaultType(options, answers)
+        const maxSubjectLength = getMaxSubjectLength(_answerType, answers.scope, options)
         if (options.minSubjectLength && processedSubject.length < options.minSubjectLength) {
           return style.red(
             `[ERROR]subject length must be greater than or equal to ${options.minSubjectLength} characters`,
@@ -137,7 +141,8 @@ export const generateQuestions = (options: CommitizenGitOptions, cz: any) => {
       transformer: (subject: string, answers: Answers) => {
         const { minSubjectLength, isIgnoreCheckMaxSubjectLength } = options
         const subjectLength = subject.length
-        const maxSubjectLength = getMaxSubjectLength(answers.type, answers.scope, options)
+        const _answerType = resolveDefaultType(options, answers)
+        const maxSubjectLength = getMaxSubjectLength(_answerType, answers.scope, options)
         let tooltip
         let isWarning = false
         if (typeof minSubjectLength === 'number' && subjectLength < minSubjectLength) {
@@ -203,10 +208,11 @@ export const generateQuestions = (options: CommitizenGitOptions, cz: any) => {
       message: options.messages?.breaking,
       completeValue: options.defaultBody || undefined,
       when: (answers: Answers) => {
+        const _answerType = resolveDefaultType(options, answers)
         if (
           options.allowBreakingChanges
-          && answers.type
-          && options.allowBreakingChanges.includes(answers.type)
+          && _answerType
+          && options.allowBreakingChanges.includes(_answerType)
         )
           return true
 

--- a/packages/cz-git/src/index.ts
+++ b/packages/cz-git/src/index.ts
@@ -92,14 +92,18 @@ async function confirmMessage(options: CommitizenGitOptions, cz: CommitizenType,
       break
 
     case 'ai-modify': {
-      const tmp = answers.type
+      options.defaultType = answers.type
       options.defaultSubject = answers.subject
-      options.useAI = false
-      const question = generateQuestions(options, cz)
-      if (question)
+      let question = generateQuestions(options, cz)
+      if (question) {
         question.shift()
+        const scopeIdx = 2
+        question = [question[scopeIdx], ...question.slice(0, scopeIdx), ...question.slice(scopeIdx + 1)]
+      }
       answers = await cz.prompt(question)
-      answers.type = tmp
+
+      options.useAI = false
+      answers.type = options.defaultType
       answers = await generateConfirmPrompt(options, cz, answers)
       confirmMessage(options, cz, answers, commit)
       break

--- a/packages/cz-git/src/index.ts
+++ b/packages/cz-git/src/index.ts
@@ -5,11 +5,11 @@
  * @copyright: Copyright (c) 2022-present Qiubin Zheng
  */
 
-import { CompleteInput, SearchCheckbox, SearchList, style } from '@cz-git/inquirer'
+import { CompleteInput, SearchCheckbox, SearchList } from '@cz-git/inquirer'
 import { configLoader } from '@cz-git/loader'
 import { editCommit, log, previewMessage } from './shared'
-import { generateAIConfirmQuestions, generateAISubjects, generateAISubjectsQuestions, generateAITypesQuestions, generateMessage, generateOptions, generateQuestions, getAliasMessage } from './generator'
-import type { CommitizenType } from './shared'
+import { generateAIPrompt, generateMessage, generateOptions, generateQuestions, getAliasMessage } from './generator'
+import type { Answers, CommitizenGitOptions, CommitizenType } from './shared'
 
 export * from './shared/types'
 export * from '@cz-git/inquirer'
@@ -35,55 +35,82 @@ export const prompter = (
     cz.registerPrompt('complete-input', CompleteInput)
 
     let answers
-    if (options.useAI) {
-      answers = await cz.prompt(generateAITypesQuestions(options))
-      console.log(style.green('ℹ'), style.bold(options.messages!.generatingByAI))
-      // Power By and Modified part of the code: https://github.com/Nutlope/aicommits
-      const subjects = await generateAISubjects(answers, options)
-      if (!Array.isArray(subjects))
-        throw new Error('subjects fetch value failed')
+    if (options.useAI)
+      answers = await generateAIPrompt(options, cz)
+    else
+      answers = await cz.prompt(generateQuestions(options, cz))
 
-      if (subjects.length === 1) {
-        answers.subject = subjects[0]
-      }
-      else {
-        const { subject } = await cz.prompt(generateAISubjectsQuestions(options, subjects))
-        answers.subject = subject
-      }
+    answers = await generateConfirmPrompt(options, cz, answers)
 
-      if (options.defaultScope)
-        answers.scope = options.defaultScope
-    }
-    else {
-      const questions = generateQuestions(options, cz)
-      answers = await cz.prompt(questions)
-    }
-
-    if (options.skipQuestions?.includes('confirmCommit')) {
-      commit(generateMessage(answers, options))
-      previewMessage(
-        generateMessage(answers, options, options.confirmColorize),
-        options.confirmColorize,
-      )
-      return 0
-    }
-    else {
-      // @ts-expect-error
-      const { confirmCommit } = await cz.prompt(generateAIConfirmQuestions(options, answers))
-      answers.confirmCommit = confirmCommit
-    }
-    switch (answers.confirmCommit) {
-      case 'edit':
-        editCommit(answers, options, commit)
-        break
-
-      case 'yes':
-        commit(generateMessage(answers, options))
-        break
-
-      default:
-        log('info', 'Commit has been canceled.')
-        break
-    }
+    await confirmMessage(options, cz, answers, commit)
   })
+}
+
+async function generateConfirmPrompt(options: CommitizenGitOptions, cz: CommitizenType, answers: Answers) {
+  const result = answers
+  if (options.skipQuestions?.includes('confirmCommit')) {
+    previewMessage(
+      generateMessage(answers, options, options.confirmColorize),
+      options.confirmColorize,
+    )
+    result.confirmCommit = 'yes'
+  }
+  else {
+    const question: any = [
+      {
+        type: 'expand',
+        name: 'confirmCommit',
+        choices: [
+          { key: 'y', name: 'Yes', value: 'yes' },
+          { key: 'n', name: 'Abort commit', value: 'no' },
+          { key: 'e', name: 'Edit message(wq: save, cq: exit)', value: 'edit' },
+        ],
+        default: 0,
+        message() {
+          previewMessage(
+            generateMessage(answers, options, options.confirmColorize),
+            options.confirmColorize,
+          )
+          return options.messages?.confirmCommit
+        },
+      },
+    ]
+    if (options.useAI)
+      question[0].choices.push({ key: 'm', name: 'Modify and additional message with prompt', value: 'ai-modify' })
+
+    const { confirmCommit } = await cz.prompt(question)
+    result.confirmCommit = confirmCommit
+  }
+
+  return result
+}
+
+async function confirmMessage(options: CommitizenGitOptions, cz: CommitizenType, answers: Answers, commit: (message: string) => void) {
+  switch (answers.confirmCommit) {
+    case 'edit':
+      editCommit(answers, options, commit)
+      break
+
+    case 'ai-modify': {
+      const tmp = answers.type
+      options.defaultSubject = answers.subject
+      options.useAI = false
+      const question = generateQuestions(options, cz)
+      if (question)
+        question.shift()
+      answers = await cz.prompt(question)
+      answers.type = tmp
+      answers = await generateConfirmPrompt(options, cz, answers)
+      confirmMessage(options, cz, answers, commit)
+      break
+    }
+
+    case 'yes':
+      commit(generateMessage(answers, options))
+      break
+
+    default:
+      log('info', 'Commit has been canceled.')
+      break
+  }
 }

--- a/packages/cz-git/src/shared/utils/util.ts
+++ b/packages/cz-git/src/shared/utils/util.ts
@@ -53,6 +53,16 @@ export const isSingleItem = (allowCustom = true, allowEmpty = true, list: Array<
   !allowCustom && !allowEmpty && Array.isArray(list) && list.length === 1
 
 /**
+ * @description: resolve AI modify mode and normal answer type and default type
+ */
+export const resolveDefaultType = (options: CommitizenGitOptions, answer: Answers) => {
+  if (!answer.type && options.useAI)
+    return options.defaultType
+
+  return answer.type || options.defaultType
+}
+
+/**
  * @description: parse scope configuration option to standard options
  */
 export const parseStandardScopes = (scopes: ScopesType): Option[] => {


### PR DESCRIPTION
## Related ISSUE

> Input follow ISSUE URL address

<!-- link #33 -->

#101 #94 

## Type Of Change

- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📝 Document (This change requires a documentation update)
- [ ] 🎨 Theme style (Theme style beautification)
- [ ] ⚠  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔨 Workflow (Workflow changes)

## Clear Describe

- feat(cz-git,czg): add modify message with prompt on AI confirm


## Description
If you are not satisfied with the current AI generated subject or want to add more message information.
You can press <kbd>m</kbd> key in the confirmation box and it will allow you to continue editing in the prompt

![CleanShot 2023-03-12 at 02 15 52@2x](https://user-images.githubusercontent.com/40693636/224505015-0b3bb686-6c18-4574-b52d-d37ec41331e8.png)

<img width="1138" alt="CleanShot 2023-03-12 at 02 16 18@2x" src="https://user-images.githubusercontent.com/40693636/224505028-d0064848-485f-4914-b499-7c5ce735be16.png">

