### PR TITLE
fix: duplicate deps in bundle (#107)

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,12 @@
     "pnpm": ">=7"
   },
   "pnpm": {
+    "overrides": {
+      "chalk": "4.1.2",
+      "color-convert": "2.0.1",
+      "resolve-from": "5.0.0",
+      "supports-color": "8.1.1"
+    },
     "peerDependencyRules": {
       "ignoreMissing": [
         "@algolia/client-search",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,11 @@
 lockfileVersion: 5.4
 
+overrides:
+  chalk: 4.1.2
+  color-convert: 2.0.1
+  resolve-from: 5.0.0
+  supports-color: 8.1.1
+
 importers:
 
   .:
@@ -694,7 +700,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-validator-identifier': 7.16.7
-      chalk: 2.4.2
+      chalk: 4.1.2
       js-tokens: 4.0.0
     dev: true
 
@@ -703,7 +709,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-validator-identifier': 7.19.1
-      chalk: 2.4.2
+      chalk: 4.1.2
       js-tokens: 4.0.0
     dev: true
 
@@ -3273,13 +3279,6 @@ packages:
   /ansi-sequence-parser/1.1.0:
     resolution: {integrity: sha512-lEm8mt52to2fT8GhciPCGeCXACSz2UwIN4X2e2LJSnZ5uAbn2/dsYdOmUXq0AtWS5cpAupysIneExOgH0Vd2TQ==}
 
-  /ansi-styles/3.2.1:
-    resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
-    engines: {node: '>=4'}
-    dependencies:
-      color-convert: 1.9.3
-    dev: true
-
   /ansi-styles/4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
@@ -3629,26 +3628,12 @@ packages:
       type-detect: 4.0.8
     dev: true
 
-  /chalk/2.4.2:
-    resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
-    engines: {node: '>=4'}
-    dependencies:
-      ansi-styles: 3.2.1
-      escape-string-regexp: 1.0.5
-      supports-color: 5.5.0
-    dev: true
-
   /chalk/4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
     dependencies:
       ansi-styles: 4.3.0
-      supports-color: 7.2.0
-    dev: true
-
-  /chalk/5.0.1:
-    resolution: {integrity: sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==}
-    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+      supports-color: 8.1.1
     dev: true
 
   /character-entities-legacy/1.1.4:
@@ -3761,21 +3746,11 @@ packages:
     engines: {node: '>=0.8'}
     dev: true
 
-  /color-convert/1.9.3:
-    resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
-    dependencies:
-      color-name: 1.1.3
-    dev: true
-
   /color-convert/2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
     dependencies:
       color-name: 1.1.4
-    dev: true
-
-  /color-name/1.1.3:
-    resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
     dev: true
 
   /color-name/1.1.4:
@@ -5517,11 +5492,6 @@ packages:
     resolution: {integrity: sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==}
     dev: true
 
-  /has-flag/3.0.0:
-    resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
-    engines: {node: '>=4'}
-    dev: true
-
   /has-flag/4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
@@ -5635,7 +5605,7 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       parent-module: 1.0.1
-      resolve-from: 4.0.0
+      resolve-from: 5.0.0
     dev: true
 
   /imurmurhash/0.1.4:
@@ -5951,7 +5921,7 @@ packages:
     dependencies:
       '@types/node': 18.13.0
       merge-stream: 2.0.0
-      supports-color: 7.2.0
+      supports-color: 8.1.1
     dev: true
 
   /jiti/1.16.2:
@@ -6277,7 +6247,7 @@ packages:
     resolution: {integrity: sha512-l0x2DvrW294C9uDCoQe1VSU4gf529FkSZ6leBl4TiqZH/e+0R7hSfHQBNut2mNygDgHwvYHfFLn6Oxb3VWj2rA==}
     engines: {node: '>=12'}
     dependencies:
-      chalk: 5.0.1
+      chalk: 4.1.2
       is-unicode-supported: 1.2.0
     dev: true
 
@@ -6715,7 +6685,7 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dependencies:
       bl: 5.0.0
-      chalk: 5.0.1
+      chalk: 4.1.2
       cli-cursor: 4.0.0
       cli-spinners: 2.6.1
       is-interactive: 2.0.0
@@ -7199,11 +7169,6 @@ packages:
   /require-from-string/2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
-    dev: true
-
-  /resolve-from/4.0.0:
-    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
-    engines: {node: '>=4'}
     dev: true
 
   /resolve-from/5.0.0:
@@ -7709,20 +7674,6 @@ packages:
       mz: 2.7.0
       pirates: 4.0.5
       ts-interface-checker: 0.1.13
-    dev: true
-
-  /supports-color/5.5.0:
-    resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
-    engines: {node: '>=4'}
-    dependencies:
-      has-flag: 3.0.0
-    dev: true
-
-  /supports-color/7.2.0:
-    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
-    engines: {node: '>=8'}
-    dependencies:
-      has-flag: 4.0.0
     dev: true
 
   /supports-color/8.1.1:


### PR DESCRIPTION
## Related ISSUE

Closes #107 

## Type Of Change

- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📝 Document (This change requires a documentation update)
- [ ] 🎨 Theme style (Theme style beautification)
- [ ] ⚠  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔨 Workflow (Workflow changes)

## Clear Describe

fix: duplicate deps in bundle

```json
"pnpm": {
    "overrides": {
      "chalk": "4.1.2",
      "color-convert": "2.0.1",
      "resolve-from": "5.0.0",
      "supports-color": "8.1.1"
    }
}
```

## Description

Fixes duplicate deps found by [Bundle Buddy](https://www.bundle-buddy.com) and additionally duplicate `resolve-from` deps found by [esbuild - Bundle Size Analyzer](https://esbuild.github.io/analyze/).

Zip file includes `metafiles` and `bundle-buddy-analysis`: [czg-metafiles.zip](https://github.com/Zhengqbbb/cz-git/files/11040129/czg-metafiles.zip)

[Bundle Buddy](https://www.bundle-buddy.com) result before:

![2023-03-22_13h47_30](https://user-images.githubusercontent.com/45284565/226911358-260a4204-bef3-4b87-9bf2-20153d3715c1.png)

[Bundle Buddy](https://www.bundle-buddy.com) result after:

![2023-03-22_13h47_36](https://user-images.githubusercontent.com/45284565/226911383-85abadac-60ba-4709-b459-9c5db17d3e39.png)

[esbuild - Bundle Size Analyzer](https://esbuild.github.io/analyze/) result before:

![2023-03-22_13h48_28](https://user-images.githubusercontent.com/45284565/226911411-7a93c7cc-68ea-4a79-bdb9-d56498ec0486.png)

**7 Warnings:**

```bash
The import path color-name resolves to multiple files in the bundle:
    [../../node_modules/.pnpm/color-name@1.1.3/node_modules/color-name/index.js](javascript:void 0)
    [../../node_modules/.pnpm/color-name@1.1.4/node_modules/color-name/index.js](javascript:void 0)

The import path color-convert resolves to multiple files in the bundle:
    [../../node_modules/.pnpm/color-convert@1.9.3/node_modules/color-convert/index.js](javascript:void 0)
    [../../node_modules/.pnpm/color-convert@2.0.1/node_modules/color-convert/index.js](javascript:void 0)

The import path has-flag resolves to multiple files in the bundle:
    [../../node_modules/.pnpm/has-flag@3.0.0/node_modules/has-flag/index.js](javascript:void 0)
    [../../node_modules/.pnpm/has-flag@4.0.0/node_modules/has-flag/index.js](javascript:void 0)

The import path ansi-styles resolves to multiple files in the bundle:
    [../../node_modules/.pnpm/ansi-styles@3.2.1/node_modules/ansi-styles/index.js](javascript:void 0)
    [../../node_modules/.pnpm/ansi-styles@4.3.0/node_modules/ansi-styles/index.js](javascript:void 0)

The import path supports-color resolves to multiple files in the bundle:
    [../../node_modules/.pnpm/supports-color@5.5.0/node_modules/supports-color/index.js](javascript:void 0)
    [../../node_modules/.pnpm/supports-color@7.2.0/node_modules/supports-color/index.js](javascript:void 0)
    [../../node_modules/.pnpm/supports-color@8.1.1/node_modules/supports-color/index.js](javascript:void 0)

The import path chalk resolves to multiple files in the bundle:
    [../../node_modules/.pnpm/chalk@2.4.2/node_modules/chalk/index.js](javascript:void 0)
    [../../node_modules/.pnpm/chalk@4.1.2/node_modules/chalk/source/index.js](javascript:void 0)

The import path resolve-from resolves to multiple files in the bundle:
    [../../node_modules/.pnpm/resolve-from@4.0.0/node_modules/resolve-from/index.js](javascript:void 0)
    [../../node_modules/.pnpm/resolve-from@5.0.0/node_modules/resolve-from/index.js](javascript:void 0)
```

[esbuild - Bundle Size Analyzer](https://esbuild.github.io/analyze/) result after:

![2023-03-22_13h48_37](https://user-images.githubusercontent.com/45284565/226911428-713e5449-25d3-4d72-8ac6-356def43b5a2.png)

## Test Case

No need for additional test case.

