### PR TITLE
feat(cz-git,czg): `defaultScope` support `string[]` to default-select for checkbox mode

### DIFF
--- a/docs/config/show.md
+++ b/docs/config/show.md
@@ -167,7 +167,7 @@ Using ==default value== can produce many ways to make the tool more suitable for
 ## defaultScope
 
 - **description** : pin scope item the top of the scope list (match `scopes` item value) 
-- **type** : `string`
+- **type** : `string` | `string[]` <sup>For checkbox mode. items will automatic checked</sup>
 - **default** : `""`
 - **other** : Initialize the completion template in **custom scope**. you can use <kbd>Tab</kbd> or <kbd>→</kbd> to quickly complete; you can also use the <kbd> Enter</kbd> output template directly.
 

--- a/docs/recipes/index.md
+++ b/docs/recipes/index.md
@@ -87,6 +87,10 @@ module.exports = {
 
 ![demo-gif](https://user-images.githubusercontent.com/40693636/170836009-26331ad3-8e7f-4183-a4af-15372b6420d6.gif) <!-- size=720x263 -->
 
+:::tip
+In checkbox mode, if `defaultScope` is passed as a `string[]`, it will default-select and pin top the options whose values match those within the `scopes` range list.
+:::
+
 ## Input mode
 
 If you don't want to use selection mode, you want to use input mode.<br>

--- a/docs/zh/config/show.md
+++ b/docs/zh/config/show.md
@@ -168,7 +168,7 @@ export ___X_CMD_THEME_COLOR_CODE="38;5;043"
 ## defaultScope
 
 - **描述** : 如果 defaultScope 与 `scopes` 选择范围列表项中的 value 相匹配就会进行星标置顶操作。
-- **类型** : `string`
+- **类型** : `string` | `string[]` <sup>[...] 在多选模式中会默认选中</sup>
 - **默认** : `""`
 - **额外** : 在 **自定义范围** 中是否使用显示默认值 
 

--- a/docs/zh/recipes/index.md
+++ b/docs/zh/recipes/index.md
@@ -86,6 +86,10 @@ module.exports = {
 
 ![demo-gif](https://user-images.githubusercontent.com/40693636/170836009-26331ad3-8e7f-4183-a4af-15372b6420d6.gif) <!-- size=720x263 -->
 
+:::tip
+在多选模式中，如果 `defaultScope` 传入的的 `string[]`, 会将 `scopes` 范围列表项中的 value 相匹配的选项进行默认选中和置顶操作
+:::
+
 ## 输入模式
 
 如果不想使用选择模式，想要使用输入模式 <sup>Input</sup>。可以使用自定义范围的输入框进行代替使用

--- a/packages/@cz-git/plugin-inquirer/examples/checkbox.js
+++ b/packages/@cz-git/plugin-inquirer/examples/checkbox.js
@@ -53,6 +53,17 @@ inquirer
       type: "search-checkbox",
       name: "testTwo",
       themeColorCode: "38;5;043",
+      separator: "|",
+      message: "Select checkbox test:",
+      source: function (answers, input) {
+        return fuzzyFilter(input, testArr2);
+      }
+    },
+    {
+      type: "search-checkbox",
+      name: "testThree",
+      themeColorCode: "38;5;043",
+      initialCheckedValue: 'test5',
       message: "Select checkbox test:",
       source: function (answers, input) {
         return fuzzyFilter(input, testArr2);
@@ -63,6 +74,7 @@ inquirer
       name: "cz",
       themeColorCode: "38;5;042",
       message: "Select scope:",
+      initialCheckedValue: ['cz-git', 'docs'],
       source: function (answers, input) {
         return fuzzyFilter(input, testArr3);
       }

--- a/packages/@cz-git/plugin-inquirer/src/shared/types/inquirer.ts
+++ b/packages/@cz-git/plugin-inquirer/src/shared/types/inquirer.ts
@@ -14,11 +14,11 @@ export interface ChoiceType<T> {
 export interface ChoicesType {
   getChoice(pointer: number): ChoiceType<any>
   /**
-   * @description: origin choices
+   * @description origin choices
    */
   choices: ChoiceType<Separator['type']>[]
   /**
-   * @description: filter Separator choices
+   * @description filter Separator choices
    */
   realChoices: ChoiceType<string>[]
 }
@@ -36,27 +36,32 @@ export interface SearchPromptQuestionOptions<T extends Answers = Answers> extend
   separator: string
 
   /**
-   * @description: support rgb color code. e.g: `38;5;042`
-   * @default: cyan
+   * @description support rgb color code. e.g: `38;5;042`
+   * @default cyan
    * @tip the rgb color see to check your number: https://github.com/sindresorhus/xterm-colors
    */
   themeColorCode?: string
 
   /**
-   * @description:
+   * @description default checked item's value array on initial
+   */
+  initialCheckedValue?: string[] | string
+
+  /**
+   * @description
    * Function to determine what options to display to user.
    * Called with previous answers object and the current user input each time the user types, it must return a promise.
    */
   source: (answersSoFar: T, input: string | undefined) => Promise<any[]>
 
   /**
-   * @description: The number of elements to show on each page.
+   * @description The number of elements to show on each page.
    */
   pageSize?: number | undefined
 
   /**
-   * @description:
-   * default false. Setting it to true turns the input into a normal text input.
+   * @description Setting it to true turns the input into a normal text input.
+   * @default false
    */
   isInitDefault?: boolean | undefined
 }

--- a/packages/cz-git/src/generator/message.ts
+++ b/packages/cz-git/src/generator/message.ts
@@ -9,6 +9,7 @@ import {
   getCurrentScopes,
   getMaxSubjectLength,
   isSingleItem,
+  isString,
   parseStandardScopes,
   useThemeCode,
   wrap,
@@ -135,7 +136,7 @@ export function generateMessage(answers: Answers,
   // resolve custom value
   const { customScope, customFooterPrefix } = answers
   answers.scope = getCustomValue(answers.scope, customScope)
-    || (options.defaultScope?.startsWith('___CUSTOM___:') && customScope)
+    || (isString(options.defaultScope) && (options.defaultScope as string).startsWith('___CUSTOM___:') && customScope)
     || ''
   answers.footerPrefix = getCustomValue(answers.footerPrefix, customFooterPrefix) as string
   // resolve single | multiple item

--- a/packages/cz-git/src/generator/questionAI.ts
+++ b/packages/cz-git/src/generator/questionAI.ts
@@ -7,6 +7,7 @@
 import { fuzzyFilter, style } from '@cz-git/inquirer'
 import type { CommitizenGitOptions, CommitizenType } from '../shared'
 import {
+  isString,
   log,
   parseStandardScopes,
   resolveListItemPinTop,
@@ -28,7 +29,7 @@ export async function generateAIPrompt(options: CommitizenGitOptions, cz: Commit
     answers.subject = subject
   }
 
-  if (options.defaultScope)
+  if (isString(options.defaultScope) && options.defaultScope)
     answers.scope = options.defaultScope
   return answers
 }

--- a/packages/cz-git/src/shared/types/options.ts
+++ b/packages/cz-git/src/shared/types/options.ts
@@ -18,7 +18,7 @@ export type Config = Omit<Partial<typeof defaultConfig>, 'scopes'> & {
   maxHeaderLength?: number
   maxSubjectLength?: number
   minSubjectLength?: number
-  defaultScope?: string
+  defaultScope?: string | string[]
   defaultSubject?: string
   defaultBody?: string
   defaultFooterPrefix?: string
@@ -161,7 +161,7 @@ export interface CommitMessageOptions {
 
 export interface GenerateAIPromptType {
   type?: string
-  defaultScope?: string
+  defaultScope?: string | string[]
   maxSubjectLength?: number
   upperCaseSubject?: boolean
   diff?: string
@@ -493,11 +493,13 @@ export interface CommitizenGitOptions {
   defaultType?: string
 
   /**
-   * @description: Whether to use display default value in custom scope
+   * @description Whether to use display default value in custom scope
    * @tip pin scope item the top of the scope list (match item value)
+   *
+   * `string[]` for checkbox mode will default-select the options whose values match those within the `scopes` range list.
    * @example: When you want to use default, just keyboard <Enter> it
    */
-  defaultScope?: string
+  defaultScope?: string | string[]
 
   /**
    * @description: default value show subject template prompt

--- a/packages/cz-git/src/shared/utils/util.ts
+++ b/packages/cz-git/src/shared/utils/util.ts
@@ -21,6 +21,10 @@ export function log(type: 'info' | 'warm' | 'err', msg: string) {
   console.info(`${colorMapping[type]}[${type}]>>>: ${msg}${colorMapping.reset}`)
 }
 
+export function isString(str: any) {
+  return typeof str === 'string'
+}
+
 /**
  * @description: count header length
  *
@@ -33,17 +37,19 @@ function countLength(target: number, typeLength: number, scope: number, emojiLen
 /**
  * @description: resolve list item pin top
  */
-export function resolveListItemPinTop(arr: {
-  name: string
-  value: any
-}[],
-defaultValue?: string) {
+export function resolveListItemPinTop(
+  arr: { name: string; value: any }[],
+  defaultValue?: string | string[],
+) {
   if (!defaultValue || defaultValue === '')
     return arr
-  const index = arr.findIndex(i => i.value === defaultValue)
-  if (!~index)
-    return arr
-  return [arr[index], ...arr.slice(0, index), ...arr.slice(index + 1)]
+  const targets = Array.isArray(defaultValue) ? defaultValue : [defaultValue]
+  targets.forEach((target) => {
+    const index = arr.findIndex(i => i.value === target)
+    if (~index)
+      arr = [arr[index], ...arr.slice(0, index), ...arr.slice(index + 1)]
+  })
+  return arr
 }
 
 /**
@@ -112,7 +118,7 @@ export function resovleCustomListTemplate(
   customAlias = 'custom',
   allowCustom = true,
   allowEmpty = true,
-  defaultValue = '',
+  defaultValue: string | string[] = '',
   scopeFilters = ['.DS_Store'],
 ) {
   let result: Array<{ name: string; value: any }> = [

--- a/scripts/czrc-schema.d.ts
+++ b/scripts/czrc-schema.d.ts
@@ -292,9 +292,11 @@ export interface CommitizenGitOptions {
   /**
    * @description: Whether to use display default value in custom scope
    * @tip pin scope item the top of the scope list (match item value)
-   * @example: When you want to use default, just keyboard <Enter> it
+   * 
+   * `string[]` for checkbox mode will default-select the options whose values match those within the `scopes` range list.
+   * @example: When you want to use default value, just keyboard <Enter> it
    */
-  defaultScope?: string
+  defaultScope?: string | string[]
 
   /**
    * @description: default value show subject template prompt


### PR DESCRIPTION
## Related ISSUE

> Input follow ISSUE URL address

<!-- link #33 -->

link #140 

## Type Of Change

- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📝 Document (This change requires a documentation update)
- [ ] 🎨 Theme style (Theme style beautification)
- [ ] ⚠  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔨 Workflow (Workflow changes)

## Clear Describe

feat(cz-git,czg): `defaultScope` support `string[]` to default-select for checkbox mode

<!-- 
input summary. e.g:
- feat: add output emoji
- docs: add `emoji` option document
-->

## Description

In checkbox mode, if `defaultScope` is passed as a `string[]`, it will default-select and pin top the options whose values match those within the `scopes` range list.


https://github.com/Zhengqbbb/cz-git/assets/40693636/f37ad34e-cbd2-4108-b19a-ea46382d3fd7

