### PR TITLE
feat(czg)!: using switch flag to replace subcmd. arg as types search keyword

### DIFF
--- a/.x-cmd/release
+++ b/.x-cmd/release
@@ -1,30 +1,12 @@
 # shellcheck shell=dash
 (
 
-# Section: Arg
-WORK_DIR="$(x wsroot)"
-DIST_PATH="$WORK_DIR"/docs/.vitepress/dist
-GITHUB_URL="https://${github_access_token}@github.com/Zhengqbbb/cz-git.git"
-BRANCH_NAME=gh-page
-
 # Section: Fuction
 deploy() {
-    param:dsl       '
-type:
-    Type    = cz brew docs all next
-    Realse  = patch minor major prepatch
-options:
-    --cmd        "select target dev command"        <>:Type
-    --version    "select realse version"            <>:Realse
-'
-    param:run
-    deploy_"${cmd}" "$version"
-}
-
-deploy_all() {
-    [ -z "$github_access_token" ] && printf "%s\n" "please provide token" && return 1
-    deploy_cz "$@"
-    deploy_docs "$@"
+    x tui form \
+        _version   "select realse version"   "" = patch minor major prepatch
+    [ -n "$_version" ] || return
+    deploy_cz "$_version"
 }
 
 deploy_cz() {
@@ -47,29 +29,11 @@ deploy_next() {
 }
 
 deploy_brew() {
-    param:dsl       '
-options:
-    --version    "input version (e.g 1.3.9)"            <>:
-'
-    param:run
-    [ -n "$(command -v brew)" ] || return 1
-    cd "$(brew --repository)"   || return 1
+    x tui form \
+        _version   "input version (e.g 1.3.9)"   ""
+    [ -n "$(command -v brew)" ] || return 
+    cd "$(brew --repository)"   || return 
     brew bump-formula-pr --url "https://registry.npmjs.org/czg/-/czg-${version}.tgz" czg 
-}
-
-deploy_docs() {
-    pnpm docs:build
-    [ ! -d "$DIST_PATH" ]   && return 1
-    cd "$DIST_PATH"         || exit
-
-    echo 'cz-git.qbb.sh' > CNAME
-    [ -d "$DIST_PATH/.git" ] && rm -rf "$DIST_PATH/.git"
-    git init \
-        && git remote add origin "$GITHUB_URL" \
-        && git checkout -b $BRANCH_NAME \
-        && git add -A \
-        && git commit -m 'build: :books: deploy docs' \
-        && git push -f "$GITHUB_URL" $BRANCH_NAME
 }
 
 # Section: Main

--- a/.x-cmd/search
+++ b/.x-cmd/search
@@ -9,21 +9,16 @@ DOC_SEARCH_CONFIG_FILE=$WORK_DIR/docs/.vitepress/build/docSearchConfig.json
 
 # Section: Fuction
 search() {
-    param:dsl       '
-type:
-    Type = only_console all google baidu bing docsearch
-options:
-    --cmd    "select target search command"        <>:Type
-'
-    param:run
-    search_"${cmd}"
+    local _command=""
+    x tui form --ctrl_exit_strategy \
+        _command   "select target search command"   "only_console" = only_console all google baidu bing docsearch
+    [ -n "$_command" ] || return 1
+    search_"${_command}"
 }
 
 log() {
     printf "\n\033[1;32m%s \033[1;33m%s \033[1;32m%s\033[0m\n" \
-    "»»»" \
-    "$1" \
-    "«««"
+        "»»»" "$1" "«««"
 }
 
 search_all() {

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -78,20 +78,22 @@ More information about configure file and options. See → [Config](/config/)
 
 ```ansi
 [90m$[0m [32mczg[0m --help
-[33mWEBSITE:[0m
-    [4mhttps://cz-git.qbb.sh/cli/[0m
-    [4mhttps://github.com/Zhengqbbb/cz-git[0m
-
 [33mSYNOPSIS:[0m
-    czg [subcommand...] [options...] [git-commit-options...]
+    czg [flag|options...] [git-commit-options...] [type list item search keywords]
 
-[33mSUBCOMMAND:[0m
-    [36mai[0m               [31mTurn on OpenAI generate subject mode[0m
-    [36mbreak[0m            [31mTurn on appends a ! after the type/scope[0m
-    [36memoji[0m            [31mTurn on output message with emoji mode[0m
-    [36mcheckbox[0m         [31mTurn on scope checkbox mode[0m
-    [36mgpg[0m              [31mTurn on use GPG sign commit message[0m
-    
+[33mFLAG:[0m
+    [36m-r, --retry[0m      [31mDirectly retry submit by the last message[0m
+    [36m-a, --all[0m        [31mAutomatically stage files that have been modified and deleted (Not new files)[0m
+    [36m-b, --break[0m      [31mTurn on appends a ! after the type/scope[0m
+    [36m-E, --emoji[0m      [31mTurn on output message with emoji mode[0m
+    [36m-S, --gpg-sign[0m   [31mTurn on use GPG sign commit message[0m
+    [36m-cb, --checkbox[0m  [31mTurn on scope checkbox mode[0m
+    [36m-ai, --ai[0m        [31mTurn on OpenAI generate subject mode[0m
+    [36m--no-ai[0m          [31mTurn off AI prompt mode in this session[0m
+    [36m--unset-proxy[0m    [31mUnset request API proxy on local configure[0m
+    [36m-h, --help[0m       [31mShow help[0m
+    [36m-v, --version[0m    [31mShow version[0m
+
 [33mOPTIONS:[0m
     [36m:, --alias=[0m      [31mDirectly submit the defined commit message[0m
     [36m--config=[0m        [31mSpecify the configuration file to use[0m
@@ -103,20 +105,14 @@ More information about configure file and options. See → [Config](/config/)
     [36m--api-endpoint=[0m  [31mSetup request OpenAI API endpoint   to local (.config/.czrc)[0m
                      [90m[default: "https://api.openai.com/v1"][0m
 
-[33mFLAG:[0m
-    [36m-r, --retry[0m      [31mDirectly retry submit by the last message[0m
-    [36m--no-ai[0m          [31mTurn off AI prompt mode in this session[0m
-    [36m--unset-proxy[0m    [31mUnset request API proxy on local configure[0m
-    [36m-h, --help[0m       [31mShow help[0m
-    [36m-v, --version[0m    [31mShow version[0m
-
 [33mEXAMPLES:[0m
     [36mczg[0m
-    [36mczg emoji[0m
+    [36mczg ch[0m | [36mczg ix[0m
+    [36mczg -a -E[0m
     [36mczg :fd[0m
     [36mczg --config="./config/cz.json"[0m
     [36mczg --api-key="sk-XXXXX"[0m
-    [36mczg ai -N=3[0m
+    [36mczg -ai -N=3[0m
 
 Extends 'git commit' options. 
 See 'git commit --help' for more information. 

--- a/docs/zh/cli/index.md
+++ b/docs/zh/cli/index.md
@@ -77,20 +77,22 @@ module.exports = {
 
 ```ansi
 [90m$[0m [32mczg[0m --help
-[33mWEBSITE:[0m
-    [4mhttps://cz-git.qbb.sh/cli/[0m
-    [4mhttps://github.com/Zhengqbbb/cz-git[0m
-
 [33mSYNOPSIS:[0m
-    czg [subcommand...] [options...] [git-commit-options...]
+    czg [flag|options...] [git-commit-options...] [type list item search keywords]
 
-[33mSUBCOMMAND:[0m
-    [36mai[0m               [31mTurn on OpenAI generate subject mode[0m
-    [36mbreak[0m            [31mTurn on appends a ! after the type/scope[0m
-    [36memoji[0m            [31mTurn on output message with emoji mode[0m
-    [36mcheckbox[0m         [31mTurn on scope checkbox mode[0m
-    [36mgpg[0m              [31mTurn on use GPG sign commit message[0m
-    
+[33mFLAG:[0m
+    [36m-r, --retry[0m      [31mDirectly retry submit by the last message[0m
+    [36m-a, --all[0m        [31mAutomatically stage files that have been modified and deleted (Not new files)[0m
+    [36m-b, --break[0m      [31mTurn on appends a ! after the type/scope[0m
+    [36m-E, --emoji[0m      [31mTurn on output message with emoji mode[0m
+    [36m-S, --gpg-sign[0m   [31mTurn on use GPG sign commit message[0m
+    [36m-cb, --checkbox[0m  [31mTurn on scope checkbox mode[0m
+    [36m-ai, --ai[0m        [31mTurn on OpenAI generate subject mode[0m
+    [36m--no-ai[0m          [31mTurn off AI prompt mode in this session[0m
+    [36m--unset-proxy[0m    [31mUnset request API proxy on local configure[0m
+    [36m-h, --help[0m       [31mShow help[0m
+    [36m-v, --version[0m    [31mShow version[0m
+
 [33mOPTIONS:[0m
     [36m:, --alias=[0m      [31mDirectly submit the defined commit message[0m
     [36m--config=[0m        [31mSpecify the configuration file to use[0m
@@ -102,20 +104,14 @@ module.exports = {
     [36m--api-endpoint=[0m  [31mSetup request OpenAI API endpoint   to local (.config/.czrc)[0m
                      [90m[default: "https://api.openai.com/v1"][0m
 
-[33mFLAG:[0m
-    [36m-r, --retry[0m      [31mDirectly retry submit by the last message[0m
-    [36m--no-ai[0m          [31mTurn off AI prompt mode in this session[0m
-    [36m--unset-proxy[0m    [31mUnset request API proxy on local configure[0m
-    [36m-h, --help[0m       [31mShow help[0m
-    [36m-v, --version[0m    [31mShow version[0m
-
 [33mEXAMPLES:[0m
     [36mczg[0m
-    [36mczg emoji[0m
+    [36mczg ch[0m | [36mczg ix[0m
+    [36mczg -a -E[0m
     [36mczg :fd[0m
     [36mczg --config="./config/cz.json"[0m
     [36mczg --api-key="sk-XXXXX"[0m
-    [36mczg ai -N=3[0m
+    [36mczg -ai -N=3[0m
 
 Extends 'git commit' options. 
 See 'git commit --help' for more information. 

--- a/packages/@cz-git/plugin-inquirer/examples/list.js
+++ b/packages/@cz-git/plugin-inquirer/examples/list.js
@@ -52,6 +52,7 @@ inquirer
       type: "search-list",
       name: "testTwo",
       themeColorCode: "38;5;043",
+      searchKeyword: "9",
       message: "Select checkbox test:",
       source: function (answers, input) {
         return fuzzyFilter(input, testArr2);

--- a/packages/@cz-git/plugin-inquirer/src/checkbox/index.ts
+++ b/packages/@cz-git/plugin-inquirer/src/checkbox/index.ts
@@ -37,8 +37,14 @@ export class SearchCheckbox extends Base {
 
   constructor(questions: Question, readline: ReadlineInterface, answers: Answers) {
     super(questions, readline, answers)
-    const { source, separator, isInitDefault, themeColorCode, initialCheckedValue } = this
-      .opt as unknown as SearchPromptQuestionOptions
+    const {
+      source,
+      separator,
+      isInitDefault,
+      themeColorCode,
+      initialCheckedValue,
+    } = this.opt as unknown as SearchPromptQuestionOptions
+
     if (!source)
       this.throwParamError('source')
     if (typeof separator === 'string')
@@ -49,6 +55,7 @@ export class SearchCheckbox extends Base {
       this.themeColorCode = themeColorCode
     if (initialCheckedValue)
       this.initialCheckedValue = initialCheckedValue
+
     this.renderChoices = new Choices([], {})
   }
 

--- a/packages/@cz-git/plugin-inquirer/src/list/index.ts
+++ b/packages/@cz-git/plugin-inquirer/src/list/index.ts
@@ -26,6 +26,7 @@ export class SearchList extends Base {
   private searching = false
   private haveSearched = false
   private themeColorCode?: string
+  private searchKeyword?: string
   private initialValue: any = -1
   private lastSearchInput?: string
   private paginator: Paginator = new Paginator(this.screen, { isInfinite: true })
@@ -34,14 +35,17 @@ export class SearchList extends Base {
 
   constructor(questions: Question, readline: ReadlineInterface, answers: Answers) {
     super(questions, readline, answers)
-    const { source, isInitDefault, themeColorCode } = this
-      .opt as unknown as SearchPromptQuestionOptions
+    const { source, isInitDefault, themeColorCode, searchKeyword } = this.opt as unknown as SearchPromptQuestionOptions
+
     if (!source)
       this.throwParamError('source')
     if (isInitDefault)
       this.initialValue = this.opt.default
     if (themeColorCode)
       this.themeColorCode = themeColorCode
+    if (searchKeyword)
+      this.searchKeyword = searchKeyword
+
     this.renderChoices = new Choices([], {})
   }
 
@@ -60,7 +64,7 @@ export class SearchList extends Base {
     events.line.pipe(takeWhile(dontHaveAnswer)).forEach(this.onSubmit.bind(this))
 
     // Init the prompt
-    this.search(undefined)
+    this.search(this.searchKeyword)
 
     return this
   }
@@ -105,7 +109,7 @@ export class SearchList extends Base {
     }
 
     if (this.firstRender)
-      content += style.dim('Use arrow keys or type to search')
+      content += this.searchKeyword || style.dim('Use arrow keys or type to search')
 
     this.firstRender = false
 

--- a/packages/@cz-git/plugin-inquirer/src/shared/types/inquirer.ts
+++ b/packages/@cz-git/plugin-inquirer/src/shared/types/inquirer.ts
@@ -43,7 +43,12 @@ export interface SearchPromptQuestionOptions<T extends Answers = Answers> extend
   themeColorCode?: string
 
   /**
-   * @description default checked item's value array on initial
+   * @description initial search keyword
+   */
+  searchKeyword?: string
+
+  /**
+   * @description default checked item's value array on initial for checkbox
    */
   initialCheckedValue?: string[] | string
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -72,14 +72,20 @@ WEBSITE:
     https://github.com/Zhengqbbb/cz-git
 
 SYNOPSIS:
-    czg [subcommand...] [options...] [git-commit-options...]
+    czg [flag|options...] [git-commit-options...] [type list item search keywords]
 
-SUBCOMMAND:
-    ai               Turn on OpenAI generate subject mode
-    break            Turn on appends a ! after the type/scope
-    emoji            Turn on output message with emoji mode
-    checkbox         Turn on scope checkbox mode
-    gpg              Turn on use GPG sign commit message
+FLAG:
+    -r, --retry      Directly retry submit by the last message
+    -a, --all        Automatically stage files that have been modified and deleted (Not new files)
+    -b, --break      Turn on appends a ! after the type/scope
+    -E, --emoji      Turn on output message with emoji mode
+    -S, --gpg-sign   Turn on use GPG sign commit message
+    -cb, --checkbox  Turn on scope checkbox mode
+    -ai, --ai        Turn on OpenAI generate subject mode
+    --no-ai          Turn off OpenAI prompt mode in this session
+    --unset-proxy    Unset request API proxy on local configure
+    -h, --help       Show help
+    -v, --version    Show version
 
 OPTIONS:
     :, --alias=      Directly submit the defined commit message
@@ -90,21 +96,16 @@ OPTIONS:
     --api-key=       Setup request OpenAI API secret key to local (.config/.czrc)
     --api-proxy=     Setup request OpenAI API proxy      to local (.config/.czrc)
     --api-endpoint=  Setup request OpenAI API endpoint   to local (.config/.czrc)
-
-FLAG:
-    -r, --retry      Directly retry submit by the last message
-    --no-ai          Turn off AI prompt mode in this session
-    --unset-proxy    Unset request API proxy on local configure
-    -h, --help       Show help
-    -v, --version    Show version
+                     [default: "https://api.openai.com/v1"]
 
 EXAMPLES:
     czg
-    czg emoji
+    czg ch | czg ix
+    czg -a -E
     czg :fd
     czg --config="./config/cz.json"
     czg --api-key="sk-XXXXX"
-    czg ai -N=3
+    czg -ai -N=3
 
 Extends 'git commit' options.
 See 'git commit --help' for more information.

--- a/packages/cli/__tests__/parse.test.ts
+++ b/packages/cli/__tests__/parse.test.ts
@@ -9,32 +9,33 @@ describe('resovleArgs', () => {
     expect(resovleArgs([])).toEqual({
       czgitArgs: {
         flag: null,
-        subCommand: null,
+        keyword: '',
       },
       gitArgs: [],
     })
   })
 
   test('resovle subcmd shoule be right', () => {
-    expect(resovleArgs(['init'])).toEqual({
+    expect(resovleArgs(['-cb'])).toEqual({
       czgitArgs: {
-        flag: null,
-        subCommand: {
-          init: true,
+        flag: {
+          checkbox: true,
         },
+        keyword: '',
       },
       gitArgs: [],
     })
 
-    expect(resovleArgs(['checkbox', 'emoji', 'hello'])).toEqual({
+    expect(resovleArgs(['--checkbox', '-E', '-b', 'ix'])).toEqual({
       czgitArgs: {
-        flag: null,
-        subCommand: {
+        flag: {
           checkbox: true,
           emoji: true,
+          break: true,
         },
+        keyword: 'ix',
       },
-      gitArgs: ['hello'],
+      gitArgs: [],
     })
   })
 
@@ -44,7 +45,7 @@ describe('resovleArgs', () => {
         flag: {
           retry: true,
         },
-        subCommand: null,
+        keyword: '',
       },
       gitArgs: [],
     })
@@ -54,7 +55,7 @@ describe('resovleArgs', () => {
         flag: {
           retry: true,
         },
-        subCommand: null,
+        keyword: '',
       },
       gitArgs: [],
     })
@@ -65,45 +66,31 @@ describe('resovleArgs', () => {
           config: './config.js',
           retry: true,
         },
-        subCommand: null,
+        keyword: '',
       },
       gitArgs: [],
     })
   })
 
   test('both resovle subcmd and flag should be right', () => {
-    expect(resovleArgs(['init', '--yes', '-y'])).toEqual({
-      czgitArgs: {
-        flag: {
-          yes: true,
-        },
-        subCommand: {
-          init: true,
-        },
-      },
-      gitArgs: [],
-    })
-
-    expect(resovleArgs(['emoji', '-r'])).toEqual({
+    expect(resovleArgs(['--emoji', '-r'])).toEqual({
       czgitArgs: {
         flag: {
           retry: true,
-        },
-        subCommand: {
           emoji: true,
         },
+        keyword: '',
       },
       gitArgs: [],
     })
 
-    expect(resovleArgs(['--config=./config.js', 'break'])).toEqual({
+    expect(resovleArgs(['--config=./config.js', '--break'])).toEqual({
       czgitArgs: {
         flag: {
           config: './config.js',
-        },
-        subCommand: {
           break: true,
         },
+        keyword: '',
       },
       gitArgs: [],
     })
@@ -114,7 +101,7 @@ describe('resovleArgs', () => {
           config: './config.js',
           alias: 'ff',
         },
-        subCommand: null,
+        keyword: '',
       },
       gitArgs: ['-a'],
     })
@@ -125,22 +112,52 @@ describe('resovleArgs', () => {
           config: './config.js',
           alias: 'dd',
         },
-        subCommand: null,
+        keyword: '',
       },
       gitArgs: ['-a'],
     })
 
-    expect(resovleArgs(['--config=./config.js', 'break', 'emoji', '-a', '--hello'])).toEqual({
+    expect(resovleArgs(['--config=./config.js', '--break', '--emoji', '-a', '--hello'])).toEqual({
+      czgitArgs: {
+        flag: {
+          break: true,
+          config: './config.js',
+          emoji: true,
+        },
+        keyword: '',
+      },
+      gitArgs: ['-a', '--hello'],
+    })
+
+    expect(resovleArgs(['--config=./config.js', '--emoji', 'ch', '-a'])).toEqual({
       czgitArgs: {
         flag: {
           config: './config.js',
-        },
-        subCommand: {
-          break: true,
           emoji: true,
         },
+        keyword: 'ch',
       },
-      gitArgs: ['-a', '--hello'],
+      gitArgs: ['-a'],
+    })
+
+    expect(resovleArgs(['--emoji', '--template', './a.txt', 'ch'])).toEqual({
+      czgitArgs: {
+        flag: {
+          emoji: true,
+        },
+        keyword: 'ch',
+      },
+      gitArgs: ['--template', './a.txt'],
+    })
+
+    expect(resovleArgs(['-a', ':a'])).toEqual({
+      czgitArgs: {
+        flag: {
+          alias: 'a',
+        },
+        keyword: '',
+      },
+      gitArgs: ['-a'],
     })
   })
 })

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "czg",
   "version": "1.7.1",
-  "description": "Interactive Commitizen CLI that generate standardized git commit message",
+  "description": "Interactive Commitizen (git commit) CLI that generate standardized git commit message",
   "author": "Zhengqbbb <zhengqbbb@gmail.com> (https://github.com/Zhengqbbb)",
   "license": "MIT",
   "homepage": "https://cz-git.qbb.sh/cli/",
@@ -14,10 +14,11 @@
     "url": "https://github.com/Zhengqbbb/cz-git/issues"
   },
   "keywords": [
-    "openai",
+    "git commit",
     "commit",
     "commit CLI",
     "commit message",
+    "openai",
     "commitizen",
     "commitizen-cli",
     "cli",

--- a/packages/cli/src/generator/czg.ts
+++ b/packages/cli/src/generator/czg.ts
@@ -28,13 +28,14 @@ export function czg(version: string, argvs: CzgitParseArgs, environment: any = {
 
       const isNoUseAI = typeof Boolean(argvs.czgitArgs.flag?.ai) && argvs.czgitArgs.flag?.ai === false
       injectEnvFlag('no_czai', isNoUseAI)
-      injectEnvFlag('czai', argvs.czgitArgs.subCommand?.ai)
-      injectEnvFlag('break', argvs.czgitArgs.subCommand?.break)
-      injectEnvFlag('emoji', argvs.czgitArgs.subCommand?.emoji)
-      injectEnvFlag('checkbox', argvs.czgitArgs.subCommand?.checkbox)
-      injectEnvFlag('CzCommitSignGPG', argvs.czgitArgs.subCommand?.gpg)
+      injectEnvFlag('czai', argvs.czgitArgs.flag?.ai)
+      injectEnvFlag('break', argvs.czgitArgs.flag?.break)
+      injectEnvFlag('emoji', argvs.czgitArgs.flag?.emoji)
+      injectEnvFlag('checkbox', argvs.czgitArgs.flag?.checkbox)
+
       injectEnvValue('cz_alias', argvs.czgitArgs.flag?.alias)
       injectEnvValue('cz_ainum', argvs.czgitArgs.flag?.['ai-num'])
+      injectEnvValue('cz_types_search_keyword', argvs.czgitArgs.keyword)
 
       console.log(`czg@${version}\n`)
       // commit

--- a/packages/cli/src/generator/help.ts
+++ b/packages/cli/src/generator/help.ts
@@ -14,15 +14,21 @@ ${style.yellow('WEBSITE:')}
 ${style.yellow('VERSION:')} ${version}
 
 ${style.yellow('SYNOPSIS:')}
-    czg [subcommand...] [options...] [git-commit-options...]
+    czg [flag|options...] [git-commit-options...] [type list item search keywords]
 
-${style.yellow('SUBCOMMAND:')}
-    ${style.cyan('ai')}               ${style.red('Turn on OpenAI generate subject mode')}
-    ${style.cyan('break')}            ${style.red('Turn on appends a ! after the type/scope')}
-    ${style.cyan('emoji')}            ${style.red('Turn on output message with emoji mode')}
-    ${style.cyan('checkbox')}         ${style.red('Turn on scope checkbox mode')}
-    ${style.cyan('gpg')}              ${style.red('Turn on use GPG sign commit message')}
-    
+${style.yellow('FLAG:')}
+    ${style.cyan('-r, --retry')}      ${style.red('Directly retry submit by the last message')}
+    ${style.cyan('-a, --all')}        ${style.red('Automatically stage files that have been modified and deleted (Not new files)')}
+    ${style.cyan('-b, --break')}      ${style.red('Turn on appends a ! after the type/scope')}
+    ${style.cyan('-E, --emoji')}      ${style.red('Turn on output message with emoji mode')}
+    ${style.cyan('-S, --gpg-sign')}   ${style.red('Turn on use GPG sign commit message')}
+    ${style.cyan('-cb, --checkbox')}  ${style.red('Turn on scope checkbox mode')}
+    ${style.cyan('-ai, --ai')}        ${style.red('Turn on OpenAI generate subject mode')}
+    ${style.cyan('--no-ai')}          ${style.red('Turn off OpenAI prompt mode in this session')}
+    ${style.cyan('--unset-proxy')}    ${style.red('Unset request API proxy on local configure')}
+    ${style.cyan('-h, --help')}       ${style.red('Show help')}
+    ${style.cyan('-v, --version')}    ${style.red('Show version')}
+
 ${style.yellow('OPTIONS:')}
     ${style.cyan(':, --alias=')}      ${style.red('Directly submit the defined commit message')}
     ${style.cyan('--config=')}        ${style.red('Specify the configuration file to use')}
@@ -34,20 +40,14 @@ ${style.yellow('OPTIONS:')}
     ${style.cyan('--api-endpoint=')}  ${style.red('Setup request OpenAI API endpoint   to local (.config/.czrc)')}
                      ${style.gray('[default: "https://api.openai.com/v1"]')}
 
-${style.yellow('FLAG:')}
-    ${style.cyan('-r, --retry')}      ${style.red('Directly retry submit by the last message')}
-    ${style.cyan('--no-ai')}          ${style.red('Turn off AI prompt mode in this session')}
-    ${style.cyan('--unset-proxy')}    ${style.red('Unset request API proxy on local configure')}
-    ${style.cyan('-h, --help')}       ${style.red('Show help')}
-    ${style.cyan('-v, --version')}    ${style.red('Show version')}
-
 ${style.yellow('EXAMPLES:')}
     ${style.cyan('czg')}
-    ${style.cyan('czg emoji')}
+    ${style.cyan('czg ch')} | ${style.cyan('czg ix')}
+    ${style.cyan('czg -a -E')}
     ${style.cyan('czg :fd')}
     ${style.cyan('czg --config="./config/cz.json"')}
     ${style.cyan('czg --api-key="sk-XXXXX"')}
-    ${style.cyan('czg ai -N=3')}
+    ${style.cyan('czg -ai -N=3')}
 
 Extends 'git commit' options. 
 See 'git commit --help' for more information. `,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -24,7 +24,7 @@ export function bootsrap(environment: any = {}, argv = process.argv) {
   const czgitVersion = require('../package.json').version
   const parsedArgs = resovleArgs(commandArgs)
 
-  if (!parsedArgs.czgitArgs.subCommand && !parsedArgs.czgitArgs.flag) {
+  if (!parsedArgs.czgitArgs.flag) {
     czg(czgitVersion, parsedArgs, environment)
     return
   }
@@ -49,14 +49,6 @@ export function bootsrap(environment: any = {}, argv = process.argv) {
     }
     else if (openAIAPIKey || openAIToken || apiProxy || unsetProxy || apiEndpoint) {
       setupAIConfig(openAIAPIKey || openAIToken, apiProxy, unsetProxy, apiEndpoint)
-      process.exit(0)
-    }
-  }
-  else if (parsedArgs.czgitArgs.subCommand) {
-    const { init: initMode } = parsedArgs.czgitArgs.subCommand
-    if (initMode) {
-      // TODO: init
-      console.log('TODO: init')
       process.exit(0)
     }
   }

--- a/packages/cli/src/shared/types/czg.ts
+++ b/packages/cli/src/shared/types/czg.ts
@@ -14,14 +14,31 @@ export type CzgitFlagList =
   | 'api-proxy'
   | 'unset-proxy'
   | 'ai'
+  | 'break'
+  | 'emoji'
+  | 'checkbox'
 
 export interface CzgitCommonFlag {
   /** option: --version|-v */
   version?: boolean
   /** option: --help|-h */
   help?: boolean
-  /** option: --no-ai */
+  /** option: --ai|-ai --no-ai */
   ai?: boolean
+  /** option: -b|--break */
+  break?: boolean
+  /** option: -cb|--checkbox */
+  checkbox?: boolean
+  /** option: -E|--emoji */
+  emoji?: boolean
+  /** option: --retry|-r */
+  retry?: boolean
+  /** TODO: option: --reback */
+  reback?: boolean
+  /** option: --hook, provide husky */
+  hook?: boolean
+  /** option: --unset-proxy */
+  'unset-proxy'?: boolean
 }
 
 export interface CzgitFlag {
@@ -39,35 +56,13 @@ export interface CzgitFlag {
   'api-proxy'?: string
   /** option: --api-endpoint="xxx" */
   'api-endpoint'?: string
-  /** option: --unset-proxy */
-  'unset-proxy'?: boolean
-  /** option: --reback|-b */
-  reback?: boolean
-  /** option: --retry|-r */
-  retry?: boolean
-  /** option: --hook, provide husky */
-  hook?: boolean
 }
 
-export interface InitFlag {
+export interface InitFlag { // TODO:
   /** option: --yes|-y */
   yes?: boolean
-}
-
-export type CzgitSubCommandList = 'init' | 'emoji' | 'ai' | 'checkbox' | 'break' | 'gpg'
-export interface CzgitSubCommand {
-  /** option: init */
+  /** option: --init */
   init?: boolean
-  /** subcmd: emoji */
-  ai?: boolean
-  /** subcmd: emoji */
-  emoji?: boolean
-  /** subcmd: checkbox */
-  checkbox?: boolean
-  /** subcmd: break */
-  break?: boolean
-  /** subcmd: gpg */
-  gpg?: boolean
 }
 
 /**
@@ -76,7 +71,7 @@ export interface CzgitSubCommand {
 export interface CzgitParseArgs {
   czgitArgs: {
     flag: (CzgitCommonFlag & CzgitFlag & InitFlag) | null
-    subCommand: CzgitSubCommand | null
+    keyword: string
   }
   gitArgs: string[]
 }

--- a/packages/cli/src/shared/utils/parse.ts
+++ b/packages/cli/src/shared/utils/parse.ts
@@ -1,20 +1,24 @@
-import minimist from 'minimist'
 import type { ParsedArgs } from 'minimist'
-import type { CzgitFlagList, CzgitParseArgs, CzgitSubCommandList } from '../types'
+import minimist from 'minimist'
+import type { CzgitFlagList, CzgitParseArgs } from '../types'
+
+const ___GIT_COMMIT_OPTIONS = [
+  '-F', '--file',
+  '--author',
+  '--date',
+  '-m', '--message',
+  '-c', '--reedit-message',
+  '-C', '--reuse-message',
+  '--fixup',
+  '--squash',
+  '--trailer',
+  '-t', '--template',
+  '--cleanup',
+  '--pathspec-from-file',
+]
 
 function deleteItem(target: string, list: string[]) {
   return list.splice(list.indexOf(target), ~list.indexOf(target) ? 1 : 0)
-}
-
-function resovleSubCmd(arg: string, cmd: CzgitSubCommandList, target: CzgitParseArgs) {
-  if (arg !== cmd)
-    return target
-  if (!target.czgitArgs.subCommand)
-    target.czgitArgs.subCommand = {}
-
-  target.czgitArgs.subCommand[cmd] = true
-  deleteItem(cmd, target.gitArgs)
-  return target
 }
 
 function resovleFlag(
@@ -42,11 +46,13 @@ function resovleFlag(
   return target
 }
 
-function resovleReverseFlag(argv: ParsedArgs,
+function resovleReverseFlag(
+  argv: ParsedArgs,
   targetFlag: string,
   flag: CzgitFlagList,
-  target: CzgitParseArgs) {
-  if (argv[flag] === undefined)
+  target: CzgitParseArgs,
+) {
+  if (argv[flag] === undefined || !target.gitArgs.includes(targetFlag))
     return target
   if (!target.czgitArgs.flag)
     target.czgitArgs.flag = {}
@@ -69,50 +75,72 @@ function resovleAlias(arg: string, target: CzgitParseArgs) {
   return target
 }
 
+function resovleSearchKeyword(arg: string, target: CzgitParseArgs) {
+  if (!arg.startsWith('-')) {
+    target.czgitArgs.keyword = arg
+    deleteItem(arg, target.gitArgs)
+  }
+
+  return target
+}
+
 /**
  * resovle process.argv by minimist
  * @param {ParsedArgs} argv
  * @return {CzgitParseArgs} czgit parsed args
  */
 export function resovleArgs(argv: string[]): CzgitParseArgs {
+  argv = argv.map(v => v.replace(/^-ai$/, '--ai').replace(/^-cb$/, '--checkbox'))
   const parseArgv = minimist(argv, {
-    boolean: true,
+    boolean: [
+      'ai',
+      'break',
+      'checkbox',
+      'emoji',
+      'retry',
+    ],
     alias: {
+      b: 'break',
+      E: 'emoji',
       v: 'version',
       h: 'help',
-      b: 'reback',
       r: 'retry',
-      y: 'yes',
       N: 'ai-num',
     },
   })
+
   let result: CzgitParseArgs = {
     czgitArgs: {
       flag: null,
-      subCommand: null,
+      keyword: '',
     },
     gitArgs: argv,
   }
 
-  if (parseArgv._.length !== 0) {
-    for (let i = 0; i < parseArgv._.length; i++) {
-      // resolve subcmd
-      result = resovleSubCmd(parseArgv._[i], 'init', result)
-      result = resovleSubCmd(parseArgv._[i], 'ai', result)
-      result = resovleSubCmd(parseArgv._[i], 'emoji', result)
-      result = resovleSubCmd(parseArgv._[i], 'checkbox', result)
-      result = resovleSubCmd(parseArgv._[i], 'break', result)
-      result = resovleSubCmd(parseArgv._[i], 'gpg', result)
-      // resolve alias
-      result = resovleAlias(parseArgv._[i], result)
+  if (argv.length !== 0) {
+    for (let i = 0; i < argv.length; i++) {
+      // resolve git options
+      if (___GIT_COMMIT_OPTIONS.includes(argv[i])) {
+        i++
+        continue
+      }
+
+      // resolve alias and keyword
+      if (!argv[i].startsWith(':'))
+        result = resovleSearchKeyword(argv[i], result)
+      else
+        result = resovleAlias(argv[i], result)
     }
   }
+
   // resolve flag
   result = resovleFlag(parseArgv, 'h', 'help', result)
-  result = resovleFlag(parseArgv, 'b', 'reback', result)
   result = resovleFlag(parseArgv, 'r', 'retry', result)
-  result = resovleFlag(parseArgv, 'y', 'yes', result)
+  result = resovleFlag(parseArgv, 'b', 'break', result)
+  result = resovleFlag(parseArgv, 'cb', 'checkbox', result)
+  result = resovleFlag(parseArgv, 'E', 'emoji', result)
   result = resovleFlag(parseArgv, 'N', 'ai-num', result)
+  result = resovleFlag(parseArgv, 'ai', 'ai', result)
   result = resovleFlag(parseArgv, 'openai-token', 'openai-token', result) // @deprecated => api-key
   result = resovleFlag(parseArgv, 'api-key', 'api-key', result)
   result = resovleFlag(parseArgv, 'api-endpoint', 'api-endpoint', result)
@@ -125,4 +153,16 @@ export function resovleArgs(argv: string[]): CzgitParseArgs {
   result = resovleReverseFlag(parseArgv, '--no-ai', 'ai', result)
 
   return result
+}
+
+// export function resovleSubCmd(arg: string, cmd: CzgitSubCommandList, target: CzgitParseArgs) {
+export function resovleSubCmd(arg: string, cmd: any, target: any) {
+  if (arg !== cmd)
+    return target
+  if (!target.czgitArgs.subCommand)
+    target.czgitArgs.subCommand = {}
+
+  target.czgitArgs.subCommand[cmd] = true
+  deleteItem(cmd, target.gitArgs)
+  return target
 }

--- a/packages/cz-git/src/generator/question.ts
+++ b/packages/cz-git/src/generator/question.ts
@@ -33,6 +33,7 @@ export function generateQuestions(options: CommitizenGitOptions, cz: any) {
       name: 'type',
       message: options.messages?.type,
       themeColorCode: options?.themeColorCode,
+      searchKeyword: process.env.cz_types_search_keyword || '',
       source: (_: unknown, input: string) => {
         const typeSource = resolveListItemPinTop(
           options.types?.concat(options.typesAppend || []) || [],

--- a/packages/cz-git/src/generator/questionAI.ts
+++ b/packages/cz-git/src/generator/questionAI.ts
@@ -25,7 +25,7 @@ export async function generateAIPrompt(options: CommitizenGitOptions, cz: Commit
     answers.subject = subjects[0]
   }
   else {
-    const { subject } = await cz.prompt(generateAISubjectsQuestions(options, subjects))
+    const { subject } = await cz.prompt(generateAISubjectsQuestions(options, subjects) as any)
     answers.subject = subject
   }
 
@@ -46,6 +46,7 @@ function generateAITypesQuestions(options: CommitizenGitOptions) {
       name: 'type',
       message: options.messages?.type,
       themeColorCode: options?.themeColorCode,
+      searchKeyword: process.env.cz_types_search_keyword || '',
       source: (_: unknown, input: string) => {
         const typeSource = resolveListItemPinTop(
           options.types?.concat(options.typesAppend || []) || [],


### PR DESCRIPTION
## Related ISSUE

> Input follow ISSUE URL address

#147 

<!-- link #33 -->

## Type Of Change

- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📝 Document (This change requires a documentation update)
- [ ] 🎨 Theme style (Theme style beautification)
- [x] ⚠  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔨 Workflow (Workflow changes)

## Clear Describe

> A clear and concise description of what update for target.

- feat(czg)!: using switch flag to replace subcmd
- feat(czg)!: command arg as types search keyword

<!-- 
input summary. e.g:
- feat: add output emoji
- docs: add `emoji` option document
-->

## Description

## Using switch flag
Actually, `subcmd` is intended for functional categorization within commands. e.g `git branch` and `git config`.
Or is action of command like `add`  `rm`. e.g `bun add` `npm uninstall`

Initially designed as `czg ai` or `czg emoji` were aimed at highlighting configure activation. However, it might be better for both to be switch flags (like `czg --retry|-r`). 
For example, when we need to activate more than two switches, the input becomes quite redundant, which hampers the quick use of the command.


```diff
- czg emoji gpg
+ czg -E -S
- git czg emoji checkbox
+ git czg -cb -E
```

## Args => using search keywords for `types` items

`czg ix` ==> will pin the `fix` item to the top of choose list ==> <kbd>Enter</kbd>

This design helps individuals whose subconscious is already familiar with the types, enabling a swift transition to inputting the `subject` <sup>(short description)</sup>

## Test Case

- [x] add parse args testcase
