### PR TITLE
fix(cz-git): incorrect maxSubjectLength on custom scope

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
     "customizable",
     "cz-customizable"
   ],
-  "packageManager": "pnpm@9.0.0",
+  "engines": {
+    "pnpm": ">=9"
+  },
   "scripts": {
     "x": "czg",
     "build": "pnpm clean && pnpm -r build",

--- a/package.json
+++ b/package.json
@@ -23,9 +23,7 @@
     "customizable",
     "cz-customizable"
   ],
-  "engines": {
-    "pnpm": ">=9"
-  },
+  "packageManager": "pnpm@9.1.2",
   "scripts": {
     "x": "czg",
     "build": "pnpm clean && pnpm -r build",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "node-fetch": "2.6.9",
     "ora": "^7.0.1",
     "pathe": "^1.1.1",
-    "pnpm": "9.0.0",
+    "pnpm": "^9.1.2",
     "rimraf": "3.0.2",
     "simple-git-hooks": "^2.9.0",
     "ts-json-schema-generator": "^1.3.0",

--- a/packages/cz-git/__tests__/util.test.ts
+++ b/packages/cz-git/__tests__/util.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest'
-import { getCurrentScopes, getMaxSubjectLength, isSingleItem } from '../src/shared'
+import { getMaxSubjectLength, getScopesList, isSingleItem } from '../src/shared'
 
 /**
  * @description: utils Test
@@ -90,17 +90,17 @@ describe('isSingleItem()', () => {
   })
 })
 
-describe('getCurrentScopes()', () => {
+describe('getScopesList()', () => {
   test('no scopes should empty', () => {
-    expect(getCurrentScopes([], {}, 'feat')).toEqual([])
-    expect(getCurrentScopes([], { test: [{ name: 'unitest' }] }, 'feat')).toEqual([])
+    expect(getScopesList([], {}, 'feat')).toEqual([])
+    expect(getScopesList([], { test: [{ name: 'unitest' }] }, 'feat')).toEqual([])
   })
   test('hit scopeOverrides should return', () => {
     const scopeOverrides = { test: [{ name: 'unitest' }] }
-    expect(getCurrentScopes(['feat'], scopeOverrides, 'test')).toEqual([{ name: 'unitest' }])
+    expect(getScopesList(['feat'], scopeOverrides, 'test')).toEqual([{ name: 'unitest' }])
   })
   test('no hit scopeOverrides should return scopes', () => {
     const scopeOverrides = { test: [{ name: 'unitest' }] }
-    expect(getCurrentScopes(['feat', 'fix'], scopeOverrides, 'feat')).toEqual(['feat', 'fix'])
+    expect(getScopesList(['feat', 'fix'], scopeOverrides, 'feat')).toEqual(['feat', 'fix'])
   })
 })

--- a/packages/cz-git/src/generator/message.ts
+++ b/packages/cz-git/src/generator/message.ts
@@ -6,8 +6,8 @@
 import { spawnSync } from 'node:child_process'
 import { style } from '@cz-git/inquirer'
 import {
-  getCurrentScopes,
   getMaxSubjectLength,
+  getScopesList,
   isSingleItem,
   isString,
   parseStandardScopes,
@@ -37,7 +37,7 @@ function getSingleParams(answers: Answers, options: CommitizenGitOptions) {
     singeIssuePrefix: '',
   }
   const scopeList = parseStandardScopes(
-    getCurrentScopes(options.scopes, options.scopeOverrides, answers.type),
+    getScopesList(options.scopes, options.scopeOverrides, answers.type),
   )
   if (isSingleItem(options.allowCustomScopes, options.allowEmptyScopes, scopeList))
     mapping.singleScope = scopeList[singleIndex].value

--- a/packages/cz-git/src/generator/question.ts
+++ b/packages/cz-git/src/generator/question.ts
@@ -130,7 +130,8 @@ export function generateQuestions(options: CommitizenGitOptions, cz: any) {
           return false
         }
         const _answerType = resolveDefaultType(options, answers)
-        const maxSubjectLength = getMaxSubjectLength(_answerType, answers.scope, options)
+        const scope = answers.scope === '___CUSTOM___' ? answers.customScope : answers.scope
+        const maxSubjectLength = getMaxSubjectLength(_answerType, scope, options)
         if (options.minSubjectLength && processedSubject.length < options.minSubjectLength) {
           return style.red(
             `[ERROR]subject length must be greater than or equal to ${options.minSubjectLength} characters`,
@@ -149,7 +150,8 @@ export function generateQuestions(options: CommitizenGitOptions, cz: any) {
         const { minSubjectLength, isIgnoreCheckMaxSubjectLength } = options
         const subjectLength = subject.length
         const _answerType = resolveDefaultType(options, answers)
-        const maxSubjectLength = getMaxSubjectLength(_answerType, answers.scope, options)
+        const scope = answers.scope === '___CUSTOM___' ? answers.customScope : answers.scope
+        const maxSubjectLength = getMaxSubjectLength(_answerType, scope, options)
         let tooltip
         let isWarning = false
         if (typeof minSubjectLength === 'number' && subjectLength < minSubjectLength) {

--- a/packages/cz-git/src/generator/question.ts
+++ b/packages/cz-git/src/generator/question.ts
@@ -7,14 +7,15 @@
 import { fuzzyFilter, style } from '@cz-git/inquirer'
 import type { Answers, CommitizenGitOptions, Option } from '../shared'
 import {
-  getCurrentScopes,
+  getAnswersScope,
+  getAnswersType,
   getMaxSubjectLength,
   getProcessSubject,
+  getScopesList,
   isSingleItem,
   isString,
   log,
   parseStandardScopes,
-  resolveDefaultType,
   resolveListItemPinTop,
   resovleCustomListTemplate,
   useThemeCode,
@@ -53,9 +54,9 @@ export function generateQuestions(options: CommitizenGitOptions, cz: any) {
       initialCheckedValue: options.defaultScope, // checkbox mode
       source: (answer: Answers, input: string) => {
         let scopeSource: Option[] = []
-        const _answerType = resolveDefaultType(options, answer)
+        const answerType = getAnswersType(options, answer)
         scopeSource = parseStandardScopes(
-          getCurrentScopes(options.scopes, options.scopeOverrides, _answerType),
+          getScopesList(options.scopes, options.scopeOverrides, answerType),
         )
         scopeSource = resovleCustomListTemplate(
           scopeSource,
@@ -83,12 +84,12 @@ export function generateQuestions(options: CommitizenGitOptions, cz: any) {
           return input.length !== 0 ? true : style.red('[ERROR] scope is required')
       },
       when: (answer: Answers) => {
-        const _answerType = resolveDefaultType(options, answer)
+        const answerType = getAnswersType(options, answer)
         return !isSingleItem(
           options.allowCustomScopes,
           options.allowEmptyScopes,
           parseStandardScopes(
-            getCurrentScopes(options.scopes, options.scopeOverrides, _answerType),
+            getScopesList(options.scopes, options.scopeOverrides, answerType),
           ),
         )
       },
@@ -111,8 +112,8 @@ export function generateQuestions(options: CommitizenGitOptions, cz: any) {
           return input.length !== 0 ? true : style.red('[ERROR] scope is required')
       },
       when: (answers: Answers) => {
-        return answers.scope === '___CUSTOM___'
-          || (isString(options.defaultScope) && (options.defaultScope as string).startsWith('___CUSTOM___:'))
+        const { isCustomScope, isInputMode } = getAnswersScope(options, answers)
+        return isCustomScope || isInputMode
       },
       transformer: (input: string) => useThemeCode(input, options.themeColorCode),
     },
@@ -125,13 +126,15 @@ export function generateQuestions(options: CommitizenGitOptions, cz: any) {
         const processedSubject = getProcessSubject(subject)
         if (processedSubject.length === 0)
           return style.red('[ERROR] subject is required')
+
         if (!options.minSubjectLength && !options.maxSubjectLength) {
           log('err', 'Error [Subject Length] Option')
           return false
         }
-        const _answerType = resolveDefaultType(options, answers)
-        const scope = answers.scope === '___CUSTOM___' ? answers.customScope : answers.scope
-        const maxSubjectLength = getMaxSubjectLength(_answerType, scope, options)
+
+        const answerType = getAnswersType(options, answers)
+        const { answerScope } = getAnswersScope(options, answers)
+        const maxSubjectLength = getMaxSubjectLength(answerType, answerScope, options)
         if (options.minSubjectLength && processedSubject.length < options.minSubjectLength) {
           return style.red(
             `[ERROR]subject length must be greater than or equal to ${options.minSubjectLength} characters`,
@@ -149,9 +152,9 @@ export function generateQuestions(options: CommitizenGitOptions, cz: any) {
       transformer: (subject: string, answers: Answers) => {
         const { minSubjectLength, isIgnoreCheckMaxSubjectLength } = options
         const subjectLength = subject.length
-        const _answerType = resolveDefaultType(options, answers)
-        const scope = answers.scope === '___CUSTOM___' ? answers.customScope : answers.scope
-        const maxSubjectLength = getMaxSubjectLength(_answerType, scope, options)
+        const answerType = getAnswersType(options, answers)
+        const { answerScope } = getAnswersScope(options, answers)
+        const maxSubjectLength = getMaxSubjectLength(answerType, answerScope, options)
         let tooltip
         let isWarning = false
         if (typeof minSubjectLength === 'number' && subjectLength < minSubjectLength) {
@@ -162,7 +165,9 @@ export function generateQuestions(options: CommitizenGitOptions, cz: any) {
             tooltip = `${subjectLength - maxSubjectLength} chars over the expected`
             isWarning = true
           }
-          else { tooltip = `${subjectLength - maxSubjectLength} chars over the limit` }
+          else {
+            tooltip = `${subjectLength - maxSubjectLength} chars over the limit`
+          }
         }
         else {
           tooltip = `${maxSubjectLength - subjectLength} more chars allowed`
@@ -220,11 +225,11 @@ export function generateQuestions(options: CommitizenGitOptions, cz: any) {
       message: options.messages?.breaking,
       completeValue: options.defaultBody || undefined,
       when: (answers: Answers) => {
-        const _answerType = resolveDefaultType(options, answers)
+        const answerType = getAnswersType(options, answers)
         if (
           options.allowBreakingChanges
-          && _answerType
-          && options.allowBreakingChanges.includes(_answerType)
+          && answerType
+          && options.allowBreakingChanges.includes(answerType)
         )
           return true
 

--- a/packages/cz-git/src/shared/utils/util.ts
+++ b/packages/cz-git/src/shared/utils/util.ts
@@ -180,7 +180,7 @@ function getEmojiStrLength(options: CommitizenGitOptions, type?: string): number
  * @description: get max subject length
  */
 export function getMaxSubjectLength(type: Answers['type'],
-  scope: Answers['scope'],
+  scope: Answers['scope'] | Answers['customScope'],
   options: CommitizenGitOptions) {
   let optionMaxLength = Infinity
   if (Array.isArray(scope))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,8 +73,8 @@ importers:
         specifier: ^1.1.1
         version: 1.1.1
       pnpm:
-        specifier: 9.0.0
-        version: 9.0.0
+        specifier: ^9.1.2
+        version: 9.1.2
       rimraf:
         specifier: 3.0.2
         version: 3.0.2
@@ -144,10 +144,10 @@ importers:
         version: 7.1.1
       unocss:
         specifier: ^0.56.1
-        version: 0.56.4(postcss@8.4.30)(rollup@3.29.3)(vite@4.4.9(@types/node@20.7.0)(terser@5.16.4))
+        version: 0.56.4(postcss@8.4.30)(rollup@2.79.1)(vite@4.4.9(@types/node@20.7.0)(terser@5.16.4))
       unplugin-vue-components:
         specifier: ^0.25.2
-        version: 0.25.2(@babel/parser@7.21.8)(rollup@3.29.3)(vue@3.3.4)
+        version: 0.25.2(@babel/parser@7.21.8)(rollup@2.79.1)(vue@3.3.4)
       vite:
         specifier: ^4.4.9
         version: 4.4.9(@types/node@20.7.0)(terser@5.16.4)
@@ -1795,6 +1795,7 @@ packages:
   acorn@8.8.0:
     resolution: {integrity: sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==}
     engines: {node: '>=0.4.0'}
+    hasBin: true
 
   add-stream@1.0.0:
     resolution: {integrity: sha512-qQLMr+8o0WC4FZGQTcJiKBVC59JylcPSrTtk6usvmIDFUOCKegapy1VHQwRbFMOFyb/inzUVqHs+eMYKDM1YeQ==}
@@ -1971,6 +1972,7 @@ packages:
   bumpp@7.2.0:
     resolution: {integrity: sha512-vQxdpWe7VzdpV4dVjpWoGwTDrKZn4eqKVmjIYUlDgrmjesXAqJnWhu+VFxazoE4pLs1q5NwDhgzK1xAFL0K+Jg==}
     engines: {node: '>=10'}
+    hasBin: true
 
   bundle-require@4.0.1:
     resolution: {integrity: sha512-9NQkRHlNdNpDBGmLpngF3EFDcwodhMUuLz9PaWYciVcQF9SE4LFjM2DB/xV1Li5JiuDMv7ZUWuC3rGbqR0MAXQ==}
@@ -3071,6 +3073,7 @@ packages:
 
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
+    hasBin: true
 
   jsesc@0.5.0:
     resolution: {integrity: sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==}
@@ -3569,8 +3572,8 @@ packages:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
     engines: {node: '>=4'}
 
-  pnpm@9.0.0:
-    resolution: {integrity: sha512-tBBnB8ciWxdIthWVlTzL6/+XtUrQXQAqo2NfYzucU81mb3zpuLxEcE8foEi5pJtVNxqy2enWZ9Hv4u8VFLzVEw==}
+  pnpm@9.1.2:
+    resolution: {integrity: sha512-En3IO56hDDK+ZdIqjvtKZfuVLo/vvf3tOb3DyX78MtMbSLAEIN8sEYes4oySHJAvDLWhNKTQMri1KVy/osaB4g==}
     engines: {node: '>=18.12'}
     hasBin: true
 
@@ -3731,6 +3734,7 @@ packages:
 
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
+    hasBin: true
 
   rollup-plugin-terser@7.0.2:
     resolution: {integrity: sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==}
@@ -3803,6 +3807,7 @@ packages:
   semver@7.3.7:
     resolution: {integrity: sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==}
     engines: {node: '>=10'}
+    hasBin: true
 
   semver@7.5.2:
     resolution: {integrity: sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==}
@@ -3855,6 +3860,7 @@ packages:
   sitemap@7.1.1:
     resolution: {integrity: sha512-mK3aFtjz4VdJN0igpIJrinf3EO8U8mxOPsTBzSsy06UtjZQJ3YY3o3Xa7zSc5nMqcMrRwlChHZ18Kxg0caiPBg==}
     engines: {node: '>=12.0.0', npm: '>=5.6.0'}
+    hasBin: true
 
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
@@ -4446,6 +4452,7 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
 
   why-is-node-running@2.2.2:
     resolution: {integrity: sha512-6tSwToZxTOcotxHeA+qGCq1mVzKR3CwcJGmVcY+QE8SHy6TnpFnh8PAvPNHYr7EcuVeG0QSMxtYCuO1ta/G/oA==}
@@ -4476,6 +4483,7 @@ packages:
 
   workbox-google-analytics@7.0.0:
     resolution: {integrity: sha512-MEYM1JTn/qiC3DbpvP2BVhyIH+dV/5BjHk756u9VbwuAhu0QHyKscTnisQuz21lfRpOwiS9z4XdqeVAKol0bzg==}
+    deprecated: It is not compatible with newer versions of GA starting with v4, as long as you are using GAv3 it should be ok, but the package is not longer being maintained
 
   workbox-navigation-preload@7.0.0:
     resolution: {integrity: sha512-juWCSrxo/fiMz3RsvDspeSLGmbgC0U9tKqcUPZBCf35s64wlaLXyn2KdHHXVQrb2cqF7I0Hc9siQalainmnXJA==}
@@ -5930,21 +5938,21 @@ snapshots:
       picomatch: 2.3.1
       rollup: 2.79.1
 
-  '@rollup/pluginutils@5.0.2(rollup@3.29.3)':
+  '@rollup/pluginutils@5.0.2(rollup@2.79.1)':
     dependencies:
       '@types/estree': 1.0.0
       estree-walker: 2.0.2
       picomatch: 2.3.1
     optionalDependencies:
-      rollup: 3.29.3
+      rollup: 2.79.1
 
-  '@rollup/pluginutils@5.0.4(rollup@3.29.3)':
+  '@rollup/pluginutils@5.0.4(rollup@2.79.1)':
     dependencies:
       '@types/estree': 1.0.0
       estree-walker: 2.0.2
       picomatch: 2.3.1
     optionalDependencies:
-      rollup: 3.29.3
+      rollup: 2.79.1
 
   '@sinclair/typebox@0.27.8': {}
 
@@ -6133,20 +6141,20 @@ snapshots:
       '@typescript-eslint/types': 5.59.6
       eslint-visitor-keys: 3.4.1
 
-  '@unocss/astro@0.56.4(rollup@3.29.3)(vite@4.4.9(@types/node@20.7.0)(terser@5.16.4))':
+  '@unocss/astro@0.56.4(rollup@2.79.1)(vite@4.4.9(@types/node@20.7.0)(terser@5.16.4))':
     dependencies:
       '@unocss/core': 0.56.4
       '@unocss/reset': 0.56.4
-      '@unocss/vite': 0.56.4(rollup@3.29.3)(vite@4.4.9(@types/node@20.7.0)(terser@5.16.4))
+      '@unocss/vite': 0.56.4(rollup@2.79.1)(vite@4.4.9(@types/node@20.7.0)(terser@5.16.4))
     optionalDependencies:
       vite: 4.4.9(@types/node@20.7.0)(terser@5.16.4)
     transitivePeerDependencies:
       - rollup
 
-  '@unocss/cli@0.56.4(rollup@3.29.3)':
+  '@unocss/cli@0.56.4(rollup@2.79.1)':
     dependencies:
       '@ampproject/remapping': 2.2.1
-      '@rollup/pluginutils': 5.0.4(rollup@3.29.3)
+      '@rollup/pluginutils': 5.0.4(rollup@2.79.1)
       '@unocss/config': 0.56.4
       '@unocss/core': 0.56.4
       '@unocss/preset-uno': 0.56.4
@@ -6263,10 +6271,10 @@ snapshots:
     dependencies:
       '@unocss/core': 0.56.4
 
-  '@unocss/vite@0.56.4(rollup@3.29.3)(vite@4.4.9(@types/node@20.7.0)(terser@5.16.4))':
+  '@unocss/vite@0.56.4(rollup@2.79.1)(vite@4.4.9(@types/node@20.7.0)(terser@5.16.4))':
     dependencies:
       '@ampproject/remapping': 2.2.1
-      '@rollup/pluginutils': 5.0.4(rollup@3.29.3)
+      '@rollup/pluginutils': 5.0.4(rollup@2.79.1)
       '@unocss/config': 0.56.4
       '@unocss/core': 0.56.4
       '@unocss/inspector': 0.56.4
@@ -8361,7 +8369,7 @@ snapshots:
 
   pluralize@8.0.0: {}
 
-  pnpm@9.0.0: {}
+  pnpm@9.1.2: {}
 
   postcss-load-config@4.0.1(postcss@8.4.30)(ts-node@10.9.1(@types/node@20.7.0)(typescript@5.2.2)):
     dependencies:
@@ -9019,10 +9027,10 @@ snapshots:
 
   universalify@2.0.0: {}
 
-  unocss@0.56.4(postcss@8.4.30)(rollup@3.29.3)(vite@4.4.9(@types/node@20.7.0)(terser@5.16.4)):
+  unocss@0.56.4(postcss@8.4.30)(rollup@2.79.1)(vite@4.4.9(@types/node@20.7.0)(terser@5.16.4)):
     dependencies:
-      '@unocss/astro': 0.56.4(rollup@3.29.3)(vite@4.4.9(@types/node@20.7.0)(terser@5.16.4))
-      '@unocss/cli': 0.56.4(rollup@3.29.3)
+      '@unocss/astro': 0.56.4(rollup@2.79.1)(vite@4.4.9(@types/node@20.7.0)(terser@5.16.4))
+      '@unocss/cli': 0.56.4(rollup@2.79.1)
       '@unocss/core': 0.56.4
       '@unocss/extractor-arbitrary-variants': 0.56.4
       '@unocss/postcss': 0.56.4(postcss@8.4.30)
@@ -9040,7 +9048,7 @@ snapshots:
       '@unocss/transformer-compile-class': 0.56.4
       '@unocss/transformer-directives': 0.56.4
       '@unocss/transformer-variant-group': 0.56.4
-      '@unocss/vite': 0.56.4(rollup@3.29.3)(vite@4.4.9(@types/node@20.7.0)(terser@5.16.4))
+      '@unocss/vite': 0.56.4(rollup@2.79.1)(vite@4.4.9(@types/node@20.7.0)(terser@5.16.4))
     optionalDependencies:
       vite: 4.4.9(@types/node@20.7.0)(terser@5.16.4)
     transitivePeerDependencies:
@@ -9048,10 +9056,10 @@ snapshots:
       - rollup
       - supports-color
 
-  unplugin-vue-components@0.25.2(@babel/parser@7.21.8)(rollup@3.29.3)(vue@3.3.4):
+  unplugin-vue-components@0.25.2(@babel/parser@7.21.8)(rollup@2.79.1)(vue@3.3.4):
     dependencies:
       '@antfu/utils': 0.7.6
-      '@rollup/pluginutils': 5.0.2(rollup@3.29.3)
+      '@rollup/pluginutils': 5.0.2(rollup@2.79.1)
       chokidar: 3.5.3
       debug: 4.3.4
       fast-glob: 3.3.1


### PR DESCRIPTION
## Related ISSUE

None

## Type Of Change

- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📝 Document (This change requires a documentation update)
- [ ] 🎨 Theme style (Theme style beautification)
- [ ] ⚠  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔨 Workflow (Workflow changes)

## Clear Describe

Fix incorrect `maxSubjectLength` when using a custom commit scope.

## Description

Previously, when using a custom commit scope, the length of `___CUSTOM___` was used to calculate the `maxSubjectLength` instead of the length of the custom scope itself.
