### PR TITLE
fix(plugin-loader): loading ESM configure using URL format

### DIFF
--- a/docs/faq/index.md
+++ b/docs/faq/index.md
@@ -8,7 +8,7 @@ sitemap:
 
 # FAQ
 
-## Error: require() of ES Module ... not supported
+## Error: Cannot require() ES Module ... not supported
 > [MODULE_TYPELESS_PACKAGE_JSON] Warning: Module type of xxxx is not specified and it doesn't parse as CommonJS.
 
 1. If you are an ESM project (i.e., `"type": "module"` in package.json) or using `export default` syntax,

--- a/docs/zh/faq/index.md
+++ b/docs/zh/faq/index.md
@@ -7,7 +7,7 @@ sitemap:
 ---
 # 常见问题
 
-## Error: require() of ES Module ... not supported
+## Error: Cannot require() ES Module ... not supported
 > [MODULE_TYPELESS_PACKAGE_JSON] Warning: Module type of xxxx is not specified and it doesn't parse as CommonJS.
 
 1. 如果你是 ESM 项目 (即 package.json 中有 `"type": "module"`) 或使用 `export default` 语法

--- a/packages/@cz-git/plugin-loader/__tests__/fixtures/6-esm-config/commitlint.config.mjs
+++ b/packages/@cz-git/plugin-loader/__tests__/fixtures/6-esm-config/commitlint.config.mjs
@@ -1,0 +1,10 @@
+import { defineConfig } from 'cz-git'
+
+export default defineConfig({
+    rules: {
+        'scope-enum': [2, 'always', ['cz-git']],
+    },
+    prompt: {
+        useEmoji: true,
+    },
+})

--- a/packages/@cz-git/plugin-loader/__tests__/fixtures/6-esm-config/package.json
+++ b/packages/@cz-git/plugin-loader/__tests__/fixtures/6-esm-config/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "test",
+  "private": true,
+  "author": "Zhengqbbb <zhengqbbb@gmail.com> (https://github.com/Zhengqbbb)",
+  "config": {
+    "commitizen": {
+      "path": "node_modules/cz-git"
+    }
+  }
+}

--- a/packages/@cz-git/plugin-loader/__tests__/loader.test.ts
+++ b/packages/@cz-git/plugin-loader/__tests__/loader.test.ts
@@ -110,4 +110,13 @@ describe('config loader', () => {
             },
         })
     }, 1000)
+
+    it('default env load esm config', async () => {
+        mockDir = await useBootstrap('./fixtures/6-esm-config')
+        const config = await loaderSpyFn({ cwd: mockDir.name })
+        expect(config).toEqual({
+            rules: { 'scope-enum': [2, 'always', ['cz-git']] },
+            prompt: { path: 'node_modules/cz-git', useEmoji: true },
+        })
+    }, 1000)
 })

--- a/packages/@cz-git/plugin-loader/src/esm-ts-loader.ts
+++ b/packages/@cz-git/plugin-loader/src/esm-ts-loader.ts
@@ -1,5 +1,6 @@
 import process from 'node:process'
 import { pathToFileURL } from 'node:url'
+import { resolve } from 'node:path'
 import { style } from '@cz-git/inquirer'
 import type { Loader } from 'cosmiconfig'
 
@@ -11,7 +12,9 @@ type LoaderError = Error & {
 export function esmTsLoader(): Loader {
     return async (cfgPath: string, _: string) => {
         try {
-            const fileUrl = pathToFileURL(cfgPath).href
+            console.log(111, cfgPath)
+            const fileUrl = pathToFileURL(resolve(cfgPath)).href
+            console.log(222, fileUrl)
             const result = await import(fileUrl)
             return result.default || result
         }

--- a/packages/@cz-git/plugin-loader/src/esm-ts-loader.ts
+++ b/packages/@cz-git/plugin-loader/src/esm-ts-loader.ts
@@ -1,6 +1,7 @@
 import process from 'node:process'
 import { pathToFileURL } from 'node:url'
 import { resolve } from 'node:path'
+import fs from 'node:fs'
 import { style } from '@cz-git/inquirer'
 import type { Loader } from 'cosmiconfig'
 
@@ -13,8 +14,11 @@ export function esmTsLoader(): Loader {
     return async (cfgPath: string, _: string) => {
         try {
             console.log(111, cfgPath)
-            const fileUrl = pathToFileURL(resolve(cfgPath)).href
-            console.log(222, fileUrl)
+            const filePath = resolve(cfgPath)
+            console.log('exists ?', fs.existsSync(filePath))
+            console.log(222, filePath)
+            const fileUrl = pathToFileURL(filePath).href
+            console.log(333, fileUrl)
             const result = await import(fileUrl)
             return result.default || result
         }

--- a/packages/@cz-git/plugin-loader/src/esm-ts-loader.ts
+++ b/packages/@cz-git/plugin-loader/src/esm-ts-loader.ts
@@ -1,7 +1,5 @@
 import process from 'node:process'
-import { pathToFileURL } from 'node:url'
 import { resolve } from 'node:path'
-import fs from 'node:fs'
 import { style } from '@cz-git/inquirer'
 import type { Loader } from 'cosmiconfig'
 
@@ -13,13 +11,7 @@ type LoaderError = Error & {
 export function esmTsLoader(): Loader {
     return async (cfgPath: string, _: string) => {
         try {
-            console.log(111, cfgPath)
-            const filePath = resolve(cfgPath)
-            console.log('exists ?', fs.existsSync(filePath))
-            console.log(222, filePath)
-            const fileUrl = pathToFileURL(filePath).href
-            console.log(333, fileUrl)
-            const result = await import(fileUrl)
+            const result = await import(fileToURL(cfgPath))
             return result.default || result
         }
         catch (e: any) {
@@ -49,4 +41,22 @@ export function esmTsLoader(): Loader {
             }
         }
     }
+}
+
+export function fileToURL(filePath: string) {
+    if (typeof filePath !== 'string')
+        throw new TypeError(`Expected a string, got ${typeof filePath}`)
+
+    let pathName = resolve(filePath)
+
+    pathName = pathName.replace(/\\/g, '/')
+
+    // Windows drive letter must be prefixed with a slash.
+    if (pathName[0] !== '/') {
+        pathName = `/${pathName}`
+    }
+
+    // Escape required characters for path components.
+    // See: https://tools.ietf.org/html/rfc3986#section-3.3
+    return encodeURI(`file://${pathName}`).replace(/[?#]/g, encodeURIComponent)
 }

--- a/packages/@cz-git/plugin-loader/src/esm-ts-loader.ts
+++ b/packages/@cz-git/plugin-loader/src/esm-ts-loader.ts
@@ -1,4 +1,5 @@
 import process from 'node:process'
+import { pathToFileURL } from 'node:url'
 import { style } from '@cz-git/inquirer'
 import type { Loader } from 'cosmiconfig'
 
@@ -10,7 +11,8 @@ type LoaderError = Error & {
 export function esmTsLoader(): Loader {
     return async (cfgPath: string, _: string) => {
         try {
-            const result = await import(cfgPath) as { default?: any }
+            const fileUrl = pathToFileURL(cfgPath).href
+            const result = await import(fileUrl)
             return result.default || result
         }
         catch (e: any) {


### PR DESCRIPTION
## Related ISSUE

> Input follow ISSUE URL address

link #216 #217

## Type Of Change

- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📝 Document (This change requires a documentation update)
- [ ] 🎨 Theme style (Theme style beautification)
- [ ] ⚠  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔨 Workflow (Workflow changes)

## Clear Describe

fix(plugin-loader): loading ESM configure using URL format

## Description

The ES module loader of Windows Node.js requires the use of a valid `file://` URL format
