### PR TITLE
fix(cz-git): trim colorized scope and subject

### DIFF
--- a/packages/cz-git/__tests__/generateMessage.test.ts
+++ b/packages/cz-git/__tests__/generateMessage.test.ts
@@ -2,6 +2,17 @@ import { describe, expect, it } from 'vitest'
 import { generateMessage } from '../src/generator'
 import type { CommitizenGitOptions } from '../src/shared'
 
+function stripAnsi(value: string) {
+    const ansiCodes = [
+        '\u001B[32m',
+        '\u001B[33m',
+        '\u001B[36m',
+        '\u001B[39m',
+        '\u001B[0m',
+    ]
+    return ansiCodes.reduce((result, code) => result.split(code).join(''), value)
+}
+
 /**
  * @description generateMessage Test
  */
@@ -53,6 +64,17 @@ describe('generateMessage()', () => {
             }
             expect(generateMessage(answers, options)).toEqual('feat: add a new feature')
         })
+
+        it('colorized custom scope should trim spaces before output', () => {
+            const options = {}
+            const answers = {
+                type: 'feat',
+                scope: '___CUSTOM___',
+                customScope: 'app  ',
+                subject: 'add a new feature',
+            }
+            expect(stripAnsi(generateMessage(answers, options, true))).toEqual('feat(app): add a new feature')
+        })
     })
 
     describe('subject', () => {
@@ -97,6 +119,16 @@ describe('generateMessage()', () => {
                 emojiAlign: 'right',
             }
             expect(generateMessage(answers, options)).toEqual('feat(app): add a new feature :sparkles:')
+        })
+
+        it('colorized subject should trim spaces before output', () => {
+            const options = {}
+            const answers = {
+                type: 'feat',
+                scope: 'app',
+                subject: 'add a new feature  ',
+            }
+            expect(stripAnsi(generateMessage(answers, options, true))).toEqual('feat(app): add a new feature')
         })
     })
 

--- a/packages/cz-git/src/generator/message.ts
+++ b/packages/cz-git/src/generator/message.ts
@@ -68,8 +68,10 @@ function addType(type: string, colorize?: boolean) {
 function addScope(scope?: string, colorize?: boolean) {
     if (!scope)
         return ''
-    scope = colorize ? style.yellow(scope) : scope
-    return scope?.trim()
+    const trimmedScope = scope.trim()
+    if (!trimmedScope)
+        return ''
+    return colorize ? style.yellow(trimmedScope) : trimmedScope
 }
 
 /** @add if markBreaking or flag add mark "!" */
@@ -104,10 +106,13 @@ function addEmoji(emojiCode: string, tempAlign: string, emojiAlign?: string) {
 function addSubject(subject?: string, colorize?: boolean, themeColorCode?: string) {
     if (!subject)
         return ''
+    const trimmedSubject = subject.trim()
+    if (!trimmedSubject)
+        return ''
     if (!colorize)
-        return subject.trim()
+        return trimmedSubject
     else
-        return useThemeCode(subject, themeColorCode).trim()
+        return useThemeCode(trimmedSubject, themeColorCode)
 }
 
 /** @add if footer or colorize return trimed footer */


### PR DESCRIPTION
## Related ISSUE

<!-- No related issue -->

## Type Of Change

- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📝 Document (This change requires a documentation update)
- [ ] 🎨 Theme style (Theme style beautification)
- [ ] ⚠  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔨 Workflow (Workflow changes)

## Clear Describe

- fix: trim colorized scope and subject before generating commit message preview

## Description

When `confirmColorize` is enabled, `scope` and `subject` were previously colorized before being trimmed.

Because ANSI color codes wrap the original text, trailing spaces inside the colored content could remain in the generated preview message. For example, a custom scope like `app  ` or a subject like `add a new feature  ` could be displayed with extra spaces in the colorized confirm preview.

This change trims `scope` and `subject` before applying color styles, so both normal and colorized output follow the same trimming behavior.

## Test Case

Added regression tests for colorized message generation:

- colorized custom scope should trim trailing spaces before output
- colorized subject should trim trailing spaces before output

Ran:

```bash
pnpm vitest run packages/cz-git/__tests__/generateMessage.test.ts
```

Also manually verified the CLI preview by running the source CLI and entering:

- custom scope: `app  `
- subject: `add a new feature  `

The confirm preview output is:

```text
feat(app): add a new feature
```

## After / Before

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/123f0967-64d0-4686-9d1e-ba77dbde24ec" />
