### PR TITLE
feat(cz-git,plugin-loader): add `apiExtraBody` option

### DIFF
--- a/docs/config/engineer.md
+++ b/docs/config/engineer.md
@@ -185,6 +185,34 @@ module.exports = {
 }
 ```
 
+## apiExtraBody
+
+- **description** : Extra fields merged into the AI request body of `/chat/completions`
+- **type** : `Record<string, unknown>`
+- **default** : `undefined`
+
+:::warning
+Set a field to `null` to **remove** it from the request body.
+
+Some models reject a field outright, where overriding its value is not enough. For example
+models which require `max_completion_tokens` reject `max_tokens` at any value, and accept
+only the default `temperature`.
+:::
+
+- **example** : use a model which requires `max_completion_tokens`
+
+```json
+// ~/.config/.czrc
+{
+  "apiModel": "gpt-5.6-luna",
+  "apiExtraBody": {
+    "max_tokens": null,
+    "temperature": null,
+    "max_completion_tokens": 4096
+  }
+}
+```
+
 ## upperCaseSubject
 
 - **description** : Whether to automatically capitalize the first character of the short description (subject)

--- a/docs/recipes/openai.md
+++ b/docs/recipes/openai.md
@@ -208,6 +208,7 @@ If you are currently using [Commitizen CLI](https://github.com/commitizen/cz-cli
   - czg CLI: `czg --no-ai`
   - Commitizen CLI + cz-git: `no_czai=1 cz`
 - If you want to **customize the prompt words** sent to OpenAI (like support **i18n**), you can use [aiQuestionCB](/config/engineer#aiquestioncb) option
+- If the model you use **rejects some of the default request fields**, you can adjust the request body with the [apiExtraBody](/config/engineer#apiextrabody) option
 - The AI **configure options** information see : [Options - AI Related](/config/engineer#useai)
 - About project or global support **configure file** information see: [Configure Template](/config/#configure-template)
 

--- a/docs/zh/config/engineer.md
+++ b/docs/zh/config/engineer.md
@@ -205,6 +205,33 @@ module.exports = {
 
 ::::
 
+## apiExtraBody
+
+- **描述** : 合并进 `/chat/completions` AI 请求体的额外字段
+- **类型** : `Record<string, unknown>`
+- **默认值** : `undefined`
+
+:::warning
+将字段设置为 `null` 可以将其从请求体中**移除**。
+
+有些模型会直接拒绝某个字段，此时仅覆盖它的值是不够的。例如需要 `max_completion_tokens`
+的模型，无论 `max_tokens` 取何值都会被拒绝，并且 `temperature` 只接受默认值。
+:::
+
+- **例子** : 使用需要 `max_completion_tokens` 的模型
+
+```json
+// ~/.config/.czrc
+{
+  "apiModel": "gpt-5.6-luna",
+  "apiExtraBody": {
+    "max_tokens": null,
+    "temperature": null,
+    "max_completion_tokens": 4096
+  }
+}
+```
+
 
 ## upperCaseSubject
 

--- a/docs/zh/recipes/openai.md
+++ b/docs/zh/recipes/openai.md
@@ -240,6 +240,7 @@ module.exports = {
   aiQuestionCB: ({ maxSubjectLength, diff }) => `用完整句子为以下 Git diff 代码写一个有见解并简洁的 Git 中文提交消息，不加任何前缀，并且内容不能超过 ${maxSubjectLength} 个字符: \`\`\`diff\n${diff}\n\`\`\``,
 }
 ```
+- 如果你使用的模型**拒绝默认请求体中的某些字段**，可以使用配置项 [apiExtraBody](/zh/config/engineer#apiextrabody) 调整请求体
 - 关于 AI 相关的配置信息 可查看 [Options - AI Related](/zh/config/engineer#useai)
 - 关于项目或全局配置文件信息 可查看 [Configure Template](/zh/config/#configure-template)
 

--- a/packages/@cz-git/plugin-loader/src/index.ts
+++ b/packages/@cz-git/plugin-loader/src/index.ts
@@ -177,6 +177,8 @@ export async function aiLoader() {
         apiEndpoint: data?.config?.apiEndpoint || '',
         apiProxy: data?.config?.apiProxy || '',
         apiModel: data?.config?.apiModel || '',
+        // Only spread the key when set, so it cannot clobber a project-level value
+        ...(data?.config?.apiExtraBody ? { apiExtraBody: data.config.apiExtraBody } : {}),
     }
 }
 

--- a/packages/cz-git/__tests__/api.test.ts
+++ b/packages/cz-git/__tests__/api.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest'
+import { useModelStrategy } from '../src/generator/api'
+import type { CommitizenGitOptions } from '../src/shared'
+
+function useOptions(apiExtraBody?: Record<string, unknown>): CommitizenGitOptions {
+    return {
+        aiModel: 'gpt-4o-mini',
+        aiNumber: 1,
+        apiEndpoint: 'https://api.openai.com/v1',
+        apiExtraBody,
+    }
+}
+
+/**
+ * @description useModelStrategy Test
+ */
+describe('useModelStrategy()', () => {
+    it('should build the default payload when apiExtraBody is not set', () => {
+        const { payload, url } = useModelStrategy(useOptions(), 'diff')
+
+        expect(url).toBe('https://api.openai.com/v1/chat/completions')
+        expect(payload).toEqual({
+            model: 'gpt-4o-mini',
+            messages: [{ role: 'user', content: 'diff' }],
+            stream: true,
+            top_p: 1,
+            temperature: 0.7,
+            max_tokens: 4096,
+            n: 1,
+        })
+    })
+
+    it('should add a field which is not in the default payload', () => {
+        const { payload } = useModelStrategy(
+            useOptions({ reasoning_effort: 'low' }),
+            'diff',
+        )
+
+        expect(payload.reasoning_effort).toBe('low')
+        expect(payload.max_tokens).toBe(4096)
+    })
+
+    it('should override a field of the default payload', () => {
+        const { payload } = useModelStrategy(
+            useOptions({ temperature: 1, max_tokens: 200 }),
+            'diff',
+        )
+
+        expect(payload.temperature).toBe(1)
+        expect(payload.max_tokens).toBe(200)
+    })
+
+    it('should remove a field when the value is null', () => {
+        const { payload } = useModelStrategy(
+            useOptions({ temperature: null }),
+            'diff',
+        )
+
+        expect('temperature' in payload).toBe(false)
+    })
+
+    it('should support models which require `max_completion_tokens`', () => {
+        const { payload } = useModelStrategy(
+            useOptions({
+                max_tokens: null,
+                temperature: null,
+                max_completion_tokens: 4096,
+            }),
+            'diff',
+        )
+
+        // These models reject `max_tokens` and `temperature: 0.7` at any value,
+        // so both have to be gone from the request body, not just overridden.
+        expect('max_tokens' in payload).toBe(false)
+        expect('temperature' in payload).toBe(false)
+        expect(payload.max_completion_tokens).toBe(4096)
+        expect(payload.stream).toBe(true)
+        expect(payload.top_p).toBe(1)
+    })
+
+    it('should not mutate the apiExtraBody option', () => {
+        const apiExtraBody = { max_tokens: null }
+        useModelStrategy(useOptions(apiExtraBody), 'diff')
+
+        expect(apiExtraBody).toEqual({ max_tokens: null })
+    })
+})

--- a/packages/cz-git/src/generator/api.ts
+++ b/packages/cz-git/src/generator/api.ts
@@ -88,17 +88,28 @@ export async function fetchOpenAIMessage(options: CommitizenGitOptions, prompt: 
 }
 
 // https://platform.openai.com/docs/api-reference/chat/create
-function useModelStrategy(options: CommitizenGitOptions, prompt: string) {
+export function useModelStrategy(options: CommitizenGitOptions, prompt: string) {
+    const payload: Record<string, unknown> = {
+        model: options.aiModel,
+        messages: [{ role: 'user', content: prompt }],
+        stream: true,
+        top_p: 1,
+        temperature: 0.7,
+        max_tokens: AI_MAX_COMPLETION_TOKENS,
+        n: options.aiNumber || 1,
+    }
+
+    // `null` deletes instead of overriding: some models reject a field at any
+    // value, e.g. `max_tokens` on models that require `max_completion_tokens`.
+    for (const [key, value] of Object.entries(options.apiExtraBody ?? {})) {
+        if (value === null)
+            delete payload[key]
+        else
+            payload[key] = value
+    }
+
     return {
-        payload: {
-            model: options.aiModel,
-            messages: [{ role: 'user', content: prompt }],
-            stream: true,
-            top_p: 1,
-            temperature: 0.7,
-            max_tokens: AI_MAX_COMPLETION_TOKENS,
-            n: options.aiNumber || 1,
-        },
+        payload,
         url: `${options.apiEndpoint}/chat/completions`,
     }
 }

--- a/packages/cz-git/src/generator/option.ts
+++ b/packages/cz-git/src/generator/option.ts
@@ -38,6 +38,7 @@ export function generateOptions(config: UserConfig): CommitizenGitOptions {
         openAIToken: process.env.CZ_OPENAI_TOKEN || process.env.CZ_OPENAI_API_KEY || promptConfig.openAIToken || defaultConfig.openAIToken,
         apiProxy: promptConfig.apiProxy || defaultConfig.apiProxy,
         apiEndpoint: promptConfig.apiEndpoint || defaultConfig.apiEndpoint,
+        apiExtraBody: promptConfig.apiExtraBody ?? defaultConfig.apiExtraBody,
         useEmoji: Boolean(emoji === '1') || promptConfig.useEmoji || defaultConfig.useEmoji,
         emojiAlign: promptConfig.emojiAlign || defaultConfig.emojiAlign,
         scopes: promptConfig.scopes ?? getEnumList(config?.rules?.['scope-enum'] as any),

--- a/packages/cz-git/src/shared/types/options.ts
+++ b/packages/cz-git/src/shared/types/options.ts
@@ -288,6 +288,17 @@ export interface CommitizenGitOptions {
     apiEndpoint?: string
 
     /**
+     * Extra fields merged into the AI request body of `/chat/completions`
+     *
+     * @note Set a field to `null` to **remove** it from the request body.
+     * Some models reject a field outright, where overriding its value is not enough.
+     * e.g. models requiring `max_completion_tokens` reject `max_tokens` at any value.
+     * @example { "max_completion_tokens": 4096, "max_tokens": null, "temperature": null }
+     * @default undefined
+     */
+    apiExtraBody?: Record<string, unknown>
+
+    /**
      * Use the callback fn can customize edit information AI question information
      *
      * @param aiParam provide some known parameters
@@ -644,6 +655,7 @@ export const defaultConfig = Object.freeze({
     openAIToken: '',
     apiProxy: '',
     apiEndpoint: 'https://api.openai.com/v1',
+    apiExtraBody: undefined,
     emojiAlign: 'center',
     scopes: [],
     scopesSearchValue: false,


### PR DESCRIPTION
## Related ISSUE

https://github.com/Zhengqbbb/cz-git/issues/261

## Type Of Change

- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 📝 Document (This change requires a documentation update)
- [ ] 🎨 Theme style (Theme style beautification)
- [ ] ⚠  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔨 Workflow (Workflow changes)

## Clear Describe

- feat: add `apiExtraBody` option to adjust the AI request body
- docs: add `apiExtraBody` option document (en / zh)

## Description

`useModelStrategy()` builds one fixed request body for every model, and none of its fields can be
reached from config. As reported in #261, models which require `max_completion_tokens` therefore
cannot be used at all: they reject `max_tokens` at any value, and accept only the default
`temperature`.

`apiExtraBody` is merged into the request body after the defaults are built.

The one design point worth reviewing: **a `null` value removes the field instead of overriding it.**
A plain merge is not enough here — sending `max_tokens` alongside `max_completion_tokens` still
fails, and `max_tokens: null` fails as well, so the key has to be absent from the JSON entirely.
`temperature`, by contrast, could be repaired by overriding it with `1`; `null` just keeps the two
cases uniform.

```json
// ~/.config/.czrc
{
  "apiModel": "gpt-5.6-luna",
  "apiExtraBody": {
    "max_tokens": null,
    "temperature": null,
    "max_completion_tokens": 4096
  }
}
```

Notes on the implementation:

- In `aiLoader()` the key is spread only when it is set, so an unset value in `~/.config/.czrc`
  cannot clobber a project-level `apiExtraBody`.
- `useModelStrategy` is now exported so it can be unit tested. It is not re-exported from
  `generator/index.ts`, so the public API is unchanged.
- No JSON schema change: the AI options (`apiModel`, `apiEndpoint`, …) are not part of
  `scripts/czrc-schema.d.ts` today, so `apiExtraBody` follows the same treatment. Happy to add them
  all if you would prefer.

### ⚠ Please review the Chinese documentation

The Chinese docs in this PR — `docs/zh/config/engineer.md` and `docs/zh/recipes/openai.md` — were
written with AI assistance. **I do not read Chinese and cannot verify the wording myself**, so
please review those two files closely rather than trusting them. I would much rather you correct
or rewrite them than merge phrasing I am unable to check.

If you prefer, I can drop the zh changes from this PR entirely and leave them to you.

## Test Case

**Unit tests** — added `packages/cz-git/__tests__/api.test.ts` (6 cases): default payload unchanged,
add a field, override a field, remove a field via `null`, the `max_completion_tokens` scenario, and
that the option object is not mutated.

```sh
pnpm test:run
# Test Files  13 passed (13)
#      Tests  116 passed (116)

pnpm lint
```

**Against the real API** — loaded the config above from `~/.config/.czrc` through `configLoader()`
→ `generateOptions()` → `useModelStrategy()`, then posted the resulting body to
`api.openai.com/v1/chat/completions`:

| config | resulting payload keys | HTTP |
| --- | --- | --- |
| `apiModel: gpt-5.6-luna` + the `apiExtraBody` above | `model, messages, stream, top_p, n, max_completion_tokens` | 200 |
| `apiModel: gpt-4o-mini`, no `apiExtraBody` | `model, messages, stream, top_p, temperature, max_tokens, n` | 200 |

The second row is the regression check: with no `apiExtraBody` set, the request body is identical to
what it was before this change.

<hr>

Unrelated note, in case it is useful: 4 tests in
`packages/@cz-git/plugin-loader/__tests__/loader.test.ts` fail on my machine both with and without
this change, because `aiLoader()` reads the real `$HOME/.config/.czrc`. They pass with a clean
`HOME`, and CI on `main` is green — so it is not a regression here, but it may be worth isolating
that test from the developer's home config.
